### PR TITLE
Extend keys map

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -33,18 +33,67 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>[4.12]</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.29</version>
+            <version>[1.7.30]</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0</version>
+            <version>[7.0.0]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>[1.64]</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>[3.0.2]</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>[2.3.4]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>[1.10.19]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>[3.9]</version>
+        </dependency>
+        <dependency>
+            <groupId>edu.berkeley.cs.jqf</groupId>
+            <artifactId>jqf-fuzz</artifactId>
+            <version>[1.3]</version>
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.12.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.4</version>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.12.2</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pgp-keys-map-test3/pom.xml
+++ b/pgp-keys-map-test3/pom.xml
@@ -26,24 +26,14 @@
         <version>2019.12-SNAPSHOT</version>
     </parent>
 
-    <artifactId>pgp-keys-map-test2</artifactId>
+    <artifactId>pgp-keys-map-test3</artifactId>
     <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>[4.7]</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <version>[2.3.3]</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>[3.7]</version>
+            <version>[3.6]</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>org-apache-maven-plugins-test</module>
         <module>pgp-keys-map-test1</module>
         <module>pgp-keys-map-test2</module>
+        <module>pgp-keys-map-test3</module>
     </modules>
 
     <scm>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -14,12 +14,36 @@
 # limitations under the License.
 #
 
-# no signature for this version
-junit:junit:(,4.8)              =
+com.beust                       = 0x67497E9D680CE8E95BD6B8F85AD66315FC018797
 
+com.github.spotbugs:spotbugs-maven-plugin = 0x3B9CD44BEEDFBDFABA22717BEEA8F6DF3031CD02
+
+com.google.code.findbugs        = 0x7616EB882DAF57A11477AAF559A252FB1199D873
+
+com.google.errorprone:*:(,2.3.3]= 0xE77417AC194160A3FABD04969A259C7EE636C5ED
+com.google.errorprone:*:[2.3.4,)= 0x7615AD56144DF2376F49D98B1669C4BB543E0445
+
+com.pholser                     = 0x517B94F8D0A46317A28D8AB30DA8A5EC02D11EAD
+
+edu.berkeley.cs.jqf             = 0x07665A503E191C320F29C6C8E7C8ECE8FE1536DC
+
+info.picocli                    = 0x8756C4F765C9AC3CB6B85D62379CE192D401AB61
+
+junit:junit:(,4.8)              =
 # it is sub key of 0x58E79B6ABC762159DC0B1591164BD2247B936711
 # https://github.com/s4u/pgpverify-maven-plugin/issues/30
 junit:junit:[4.8,)              = 0xD4C89EA4AAF455FD88B22087EFE8086F9E93774E
+
+ognl                            = 0x8926173648953916A0A4F290F721C545D0CAA2E3
+
+org.antlr                       =
+
+org.apache.commons:commons-lang3:(,3.6] = 0xCD5464315F0B98C77E6E8ECD9DAADC1C9FCC82D0
+org.apache.commons:commons-lang3:[3.7]  = 0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB
+org.apache.commons:commons-lang3:[3.8,) = 0xB6E73D84EA4FCC47166087253FAAD2CD5ECBB314
+org.apache.commons              = 0xB6E73D84EA4FCC47166087253FAAD2CD5ECBB314
+
+org.apache.felix                = 0xA4DED8965C2E1C818217CB91CE2B7FF675D78E92
 
 org.apache.maven.plugins        = \
                                   0x0CDE80149711EB46DFF17AE421A24B3F8B0F594A, \
@@ -40,13 +64,21 @@ org.apache.maven.plugins        = \
                                   0xF4C53F3061834D885726D258AC2D56EAF0E309FF, \
                                   0xFA77DCFEF2EE6EB2DEBEDD2C012579464D01C06A
 
-org.apache.felix                = 0xA4DED8965C2E1C818217CB91CE2B7FF675D78E92
+org.bouncycastle                = 0x08F0AAB4D0C1A4BDDE340765B341DDB020FCB6AB
 
-com.beust                       = 0x67497E9D680CE8E95BD6B8F85AD66315FC018797
+org.codehaus.mojo:versions-maven-plugin = 0xF254B35617DC255D9344BCFA873A8E86B4372146
 
 org.hamcrest                    = 0x4DB1A49729B053CAF015CEE9A6ADFC93EF34893E
 
 org.jacoco                      = 0xA413F67D71BEEC23ADD0CE0ACB43338E060CF9FA
+
+org.javaruntype                 = 0x839323A4780D5BF9A6978970152888E10EF880B3
+
+org.javassist                   = 0x666A4692CE11B7B3F4EB7B3410066A9707090CF9
+
+org.mockito                     = 0xCC4483CD6A3EB2939B948667A1B4460D8BA7B9AF
+
+org.ow2.asm                     =
 
 org.simplify4u.*                = 0x6636274B2E8BEA9D15A61143F8484389379ACEAC
 
@@ -55,3 +87,6 @@ org.slf4j                       = 0x475F3B8E59E6E63AA78067482C7B12F2A511E325
 org.sonatype.plugins            = 0x2BCBDD0F23EA1CAFCC11D4860374CF2E8DD1BDFD
 
 org.testng                      = 0xDCBA03381EF6C89096ACD985AC5EC74981F9CDA6
+
+ru.vyarus                       = 0xD35AD4AED58AF7DBA740648243F63FDD328B612F
+


### PR DESCRIPTION
- Upgraded some dependency versions.
- Defined versions using fixed-version notation to avoid accidental influencing by dependencies pull in through the dependency tree.
- Added new entries in keys map, and added corresponding dependencies and build plug-ins in `pgp-keys-map-test1`.
- Added version distinction for `apache-commons:commons-lang3`. We might want to generalize further in the future, although I cannot be sure if this is actually necessary right now.