### PR TITLE
New key for org.springframework

### DIFF
--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -534,7 +534,9 @@ org.sonatype.*                  = \
                                   0xE78AA45938D10249E08CC1C752E6585E0102B84D
 
 
-org.springframework.*           = 0xE2ACB037933CDEAAB7BF77D49A2C7A98E457C53D
+org.springframework.*           = \
+                                  0x8756C4F765C9AC3CB6B85D62379CE192D401AB61, \
+                                  0xE2ACB037933CDEAAB7BF77D49A2C7A98E457C53D
 
 org.testng                      = 0xDCBA03381EF6C89096ACD985AC5EC74981F9CDA6
 


### PR DESCRIPTION
- `spring-framework` from version 5.3.1
- `spring-boot` from version 2.4.0 

use new key for signing artifacts, now key: `0x8756c4f765c9ac3cb6b85d62379ce192d401ab61` is used.
As we see it is key bellong to `Bintray` and key id is consistent with the description 
https://www.jfrog.com/confluence/display/BT/Managing+Uploaded+Content#ManagingUploadedContent-SigningwiththeBintrayKey
