### PR TITLE
noSig for slide

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -174,6 +174,18 @@
             <artifactId>jqf-fuzz</artifactId>
             <version>[1.7]</version>
         </dependency>
+        <dependency>
+            <groupId>slide</groupId>
+            <artifactId>slide-webdavlib</artifactId>
+            <version>[2.1]</version>
+            <exclusions>
+                <!-- de.zeigermann.xml:xml-im-exporter is not yet in pgp-keys-map -->
+                <exclusion>
+                    <groupId>de.zeigermann.xml</groupId>
+                    <artifactId>xml-im-exporter</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -645,6 +645,8 @@ ru.vyarus                       = 0xD35AD4AED58AF7DBA740648243F63FDD328B612F
 
 saxpath                         = noSig
 
+slide                           = noSig
+
 sslext                          = noSig
 
 stax                            = noSig


### PR DESCRIPTION
All artifacts for groupId "slide" are from around 2005, and none
of them have any signatures.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
