### PR TITLE
noSig for de.zeigermann.xml:xml-im-exporter:1.1

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -74,6 +74,11 @@
             <type>pom</type>
         </dependency>
         <dependency>
+            <groupId>de.zeigermann.xml</groupId>
+            <artifactId>xml-im-exporter</artifactId>
+            <version>[1.1]</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>[4.13.2]</version>
@@ -178,13 +183,6 @@
             <groupId>slide</groupId>
             <artifactId>slide-webdavlib</artifactId>
             <version>[2.1]</version>
-            <exclusions>
-                <!-- de.zeigermann.xml:xml-im-exporter is not yet in pgp-keys-map -->
-                <exclusion>
-                    <groupId>de.zeigermann.xml</groupId>
-                    <artifactId>xml-im-exporter</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -204,6 +204,8 @@ com.vaadin.external.google      = 0xCC57399D74CD7E4768ED6FA4CA62973FBF0451C0
 
 com.vladsch.flexmark            = 0x4008F9DFF7DBC968F35F9E712642156411CCE8B3
 
+de.zeigermann.xml:xml-im-exporter:1.1 = noSig
+
 dom4j:dom4j                     = noSig
 
 doxia:doxia-sink-api:1.0-alpha-4 = noSig


### PR DESCRIPTION
This is the only artifact for groupId "de.zeigermann.xml", and is
also from the year 2005 without any signatures.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
