### PR TITLE
noSig for taglibs

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -184,6 +184,11 @@
             <artifactId>slide-webdavlib</artifactId>
             <version>[2.1]</version>
         </dependency>
+        <dependency>
+            <groupId>taglibs</groupId>
+            <artifactId>standard</artifactId>
+            <version>[1.1.2]</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -653,6 +653,8 @@ sslext                          = noSig
 
 stax                            = noSig
 
+taglibs                         = noSig
+
 velocity                        = noSig
 
 wsdl4j                          = noSig


### PR DESCRIPTION
All artifacts for groupId "taglibs" are from around 2005, and none
of them have any signatures.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
