### PR TITLE
noSig for eu.medsea.mimeutil:mime-util

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -79,6 +79,11 @@
             <version>[1.1]</version>
         </dependency>
         <dependency>
+            <groupId>eu.medsea.mimeutil</groupId>
+            <artifactId>mime-util</artifactId>
+            <version>[2.1.3]</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>[4.13.2]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -212,6 +212,8 @@ doxia:doxia-sink-api:1.0-alpha-4 = noSig
 
 edu.berkeley.cs.jqf             = 0x07665A503E191C320F29C6C8E7C8ECE8FE1536DC
 
+eu.medsea.mimeutil:mime-util    = noSig
+
 geronimo-spec                   = noSig
 
 info.picocli                    = 0x8756C4F765C9AC3CB6B85D62379CE192D401AB61


### PR DESCRIPTION
This is the only artifactId in groupId "eu.medsea.mimeutil".

We specified a version range matching the published artifacts.
If a newer version is ever released, we would expect a signature.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
