### PR TITLE
Added signatures for the subset of xml-apis that are signed

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -208,6 +208,26 @@
             <artifactId>standard</artifactId>
             <version>[1.1.2]</version>
         </dependency>
+        <dependency>
+            <!-- In version 1.3.03, only pom is signed -->
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>[1.3.03]</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <!-- In version 1.4.01, all artifacts are signed -->
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>[1.4.01]</version>
+        </dependency>
+        <dependency>
+            <!-- In all other versions, nothing is signed -->
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>[1.3.04]</version>
+            <classifier>sources</classifier>
+        </dependency>
     </dependencies>
 
     <build>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -670,6 +670,8 @@ xalan:xalan                     = 0x44FBDBBC1A00FE414F1C1873586654072EAD6677
 xerces:xercesImpl:(0,2.9.1]     = noSig
 xerces                          = 0x6E13156C0EE653F0B984663AB95BBD3FA43C4492
 
+xml-apis:xml-apis:pom:1.3.03    = 0x6E13156C0EE653F0B984663AB95BBD3FA43C4492
+xml-apis:xml-apis:1.4.01        = 0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB
 xml-apis                        = noSig
 
 xmlpull                         = noSig


### PR DESCRIPTION
In version 1.3.03, only pom is signed.
In version 1.4.01, all artifacts are signed.
In all other versions, nothing is signed.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
