### PR TITLE
Refined keys for groupId "javax.ws.rs"

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -91,6 +91,24 @@
             <version>[1.1]</version>
         </dependency>
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>[2.1.1]</version>
+        </dependency>
+        <dependency>
+            <!-- In version 1.1-ea, all artifacts are signed -->
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+            <version>[1.1-ea]</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <!-- In all other versions, nothing is signed -->
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+            <version>[1.1.1]</version>
+        </dependency>
+        <dependency>
             <groupId>jgraph</groupId>
             <artifactId>jgraph</artifactId>
             <!-- Cannot use "[5.13.0.0]" due to incomplete maven-metadata.xml at

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -264,7 +264,12 @@ javax.servlet:servlet-api:2.3   = noSig
 javax.servlet                   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 
 javax.validation                = noSig
-javax.ws.rs                     = noSig
+
+javax.ws.rs:javax.ws.rs-api:(,2.1]   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
+javax.ws.rs:javax.ws.rs-api:[2.1.1,) = 0x4BD9AEC34B75BE14431C8878160A876EB62C9DBE
+
+javax.ws.rs:jsr311-api:1.1-ea   = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF88103E
+javax.ws.rs:jsr311-api          = noSig
 
 javax.xml.bind                  = \
                                   0x70CD19BFD9F6C330027D6F260315BFB7970A144F, \


### PR DESCRIPTION
javax.ws.rs:jsr311-api:1.1-ea was found signed, while all other versions are
not signed.  The signing key is found on other artifacts already in the key
map.

javax.ws.rs:javax.ws.rs-api:(,2.1] was signed by a key already in the key map
for other javax.* artifacts.

javax.ws.rs:javax.ws.rs-api:[2.1.1,) signature resolves to
"Eclipse JAX-RS Project <jaxrs-dev@eclipse.org>", which corresponds to the
Java EE project being moved to Eclipse for a while before being moved to
Apache/Jakarta

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
