### PR TITLE
new key for org.lucee:xalan[-serializer]

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -266,6 +266,16 @@
             <version>[7.1.4]</version>
         </dependency>
         <dependency>
+            <groupId>org.lucee</groupId>
+            <artifactId>xalan</artifactId>
+            <version>[2.7.2]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.lucee</groupId>
+            <artifactId>xalan-serializer</artifactId>
+            <version>[2.7.2]</version>
+        </dependency>
+        <dependency>
             <groupId>org.ostermiller</groupId>
             <artifactId>utils</artifactId>
             <!-- Cannot use "[1.07.00]" due to missing maven-metadata.xml at

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -614,6 +614,9 @@ org.jvnet.staxex                = 0x06A4D15D9FA796BA5DECF592CE8B1D1D2530EDC5
 
 org.libreoffice                 = 0xC2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3
 
+org.lucee:xalan                 = 0x26BA3E8B6A185070F538B1C15C3F925A060D5930
+org.lucee:xalan-serializer      = 0x26BA3E8B6A185070F538B1C15C3F925A060D5930
+
 org.mockito                     = \
                                   0x147B691A19097624902F4EA9689CBE64F4BC997F, \
                                   0xCC4483CD6A3EB2939B948667A1B4460D8BA7B9AF


### PR DESCRIPTION
Signature resolves to "Lucee <info@lucee.org>"

These are a one-off repackaging of the latest version of Xalan.  Unlike the
original packaging, they do not contain any split-packages, and may thus be used
as Java 9+ JPMS filename-based automatic modules.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
