### PR TITLE
new key for com.zaxxer:SparseBitSet

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -101,6 +101,11 @@
             <version>[2.0.1]</version>
         </dependency>
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>SparseBitSet</artifactId>
+            <version>[1.2]</version>
+        </dependency>
+        <dependency>
             <groupId>de.zeigermann.xml</groupId>
             <artifactId>xml-im-exporter</artifactId>
             <version>[1.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -217,6 +217,8 @@ com.vladsch.flexmark            = 0x4008F9DFF7DBC968F35F9E712642156411CCE8B3
 
 com.yworks                      = 0xF5B2464C77784BC252CA10B75420D536C1EC35CE
 
+com.zaxxer:SparseBitSet         = 0x9579802DC3E15DE9C389239FC0D48A119CE7EE7B
+
 de.zeigermann.xml:xml-im-exporter:1.1 = noSig
 
 dnsjava:dnsjava                 = 0xE06A36F67D8C1BD13F1F278D0CA7139CBC7026F9


### PR DESCRIPTION
Signature resolves to "Leo Bayer <lfbayer@gmail.com>"

Leo Bayer is also the committer on the related GitHub release:
https://github.com/brettwooldridge/SparseBitSet/releases/tag/SparseBitSet-1.2

Leo Bayer is also listed as a developer on other com.zaxxer projects, but I
do not want to assume them as a signer beyond SparseBitSet:
https://search.maven.org/artifact/com.zaxxer/sansorm

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
