### PR TITLE
new key for jakarta.transaction

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -173,6 +173,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>[2.0.0]</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>[4.13.2]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -243,6 +243,8 @@ jakarta.annotation              = 0xF6CE460FDBE1AABD1A96456737ECFC571637667C # m
 
 jakarta.jws                     = 0xCB3B6379F3D113FA3D7CB45F2776BC4F5165A5EB
 
+jakarta.transaction             = 0x1A2A6D7F079CF627566ABD869B26CED3E3BA51C3
+
 jakarta.validation              = 0x84E640DF8E94CB8CD2BEB9AE99059A5DDE1B175D # master key
 jakarta.xml.bind                = 0xDD46DEC275B1F230ACCE4EEB083891AD4774845A # master key
 


### PR DESCRIPTION
Signature resolves to "Eclipse Project for JTA <jta-dev@eclipse.org>",
which is consistent with Java EE being moved to Eclipse.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
