### PR TITLE
Additional keys for net.java.dev.jna

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -178,6 +178,16 @@
             <version>[4.13.2]</version>
         </dependency>
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>[5.8.0]</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>platform</artifactId>
+            <version>[3.5.2]</version>
+        </dependency>
+        <dependency>
             <groupId>net.sourceforge.barbecue</groupId>
             <artifactId>barbecue</artifactId>
             <!-- Cannot use "[1.5-beta1]" due to missing maven-metadata.xml at

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -321,7 +321,10 @@ net.bytebuddy                   = \
 
 net.java.dev.javacc             = noSig
 
-net.java.dev.jna                = 0x47063E8BA7A6450E4A52E7AE466CAED6E0747D50
+net.java.dev.jna                = \
+                                  0x47063E8BA7A6450E4A52E7AE466CAED6E0747D50, \
+                                  0x78DA3333F653B1C54A938BE24DB7BC57DFDBCEA4, \
+                                  0xFA7929F83AD44C4590F6CC6815C71C0A4E0B8EDD
 
 net.java.dev.stax-utils         = noSig
 


### PR DESCRIPTION
4DB7BC57DFDBCEA4 resolves to "Timothy Wall <twall@users.sf.net>".
Timothy Wall is associated with related GitHub projects:
https://github.com/java-native-access/jna#community-and-support

15C71C0A4E0B8EDD resolves to "Matthias Bläsing <mblaesing@doppel-helix.eu>".
Matthias Bläsing is listed as a developer:
https://github.com/java-native-access/jna/blob/d367f0220be55b5638b3d324473ef0a7e654d83c/pom-jna-platform.xml#L53

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
