### PR TITLE
new key for javax.xml.rpc

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -140,6 +140,11 @@
             <version>[1.1.1]</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.rpc</groupId>
+            <artifactId>javax.xml.rpc-api</artifactId>
+            <version>[1.1.2]</version>
+        </dependency>
+        <dependency>
             <groupId>jgraph</groupId>
             <artifactId>jgraph</artifactId>
             <!-- Cannot use "[5.13.0.0]" due to incomplete maven-metadata.xml at

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -292,6 +292,8 @@ javax.xml.bind                  = \
                                   0x70CD19BFD9F6C330027D6F260315BFB7970A144F, \
                                   0xB38E195D438D44A1A8D2D2203575E1C767076CA8
 
+javax.xml.rpc                   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
+
 javax.xml.stream                = noSig
 
 jaxen:jaxen:(,1.1.1]            = noSig


### PR DESCRIPTION
This signature is already in the map for other Oracle-signed artifacts.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
