### PR TITLE
new key for org.apache.taglibs

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -241,6 +241,11 @@
             <version>[4.5.13]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-spec</artifactId>
+            <version>[1.2.5]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-api</artifactId>
             <version>[10.1.0-M2]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -454,6 +454,8 @@ org.apache.struts:struts-core:pom:1.3.8   = badSig
 org.apache.struts:struts-taglib:pom:1.3.8 = badSig
 org.apache.struts:struts-tiles:pom:1.3.8  = badSig
 
+org.apache.taglibs              = 0x8B46CA49EF4837B8C7F292DAA54AD08EA7A0233C
+
 org.apache.tomcat.*             = \
                                   0x48F8E69F6390C9F25CFEDCD268248959359E722B, \
                                   0x713DA88BE50911535FE716F5208B0AB1D63011C7, \


### PR DESCRIPTION
This signature is included in tomcat KEYS file at https://github.com/apache/tomcat/blob/85ff05f396ffdb19a2df69123f51f8c784e95ee0/KEYS#L593

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
