### PR TITLE
new key for de.rototor.pdfbox

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -106,6 +106,11 @@
             <version>[1.2]</version>
         </dependency>
         <dependency>
+            <groupId>de.rototor.pdfbox</groupId>
+            <artifactId>graphics2d</artifactId>
+            <version>[3.0.0-RC1]</version>
+        </dependency>
+        <dependency>
             <groupId>de.zeigermann.xml</groupId>
             <artifactId>xml-im-exporter</artifactId>
             <version>[1.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -221,6 +221,8 @@ com.yworks                      = 0xF5B2464C77784BC252CA10B75420D536C1EC35CE
 
 com.zaxxer:SparseBitSet         = 0x9579802DC3E15DE9C389239FC0D48A119CE7EE7B
 
+de.rototor.pdfbox               = 0x8608E5C5E09DCCE835B50BCD1158D77CDB3A70BB
+
 de.zeigermann.xml:xml-im-exporter:1.1 = noSig
 
 dnsjava:dnsjava                 = 0xE06A36F67D8C1BD13F1F278D0CA7139CBC7026F9


### PR DESCRIPTION
The signature matches recent verified commits on the project, such as
https://github.com/rototor/pdfbox-graphics2d/commit/b67d59e8876c817690a330912ea84d5a0b0362bb

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
