### PR TITLE
Additional key for org.apache.xmlgraphics

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -261,6 +261,11 @@
             <version>[10.1.0-M2]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-all</artifactId>
+            <version>[1.14]</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-component-annotations</artifactId>
             <version>[2.1.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -478,6 +478,7 @@ org.apache.xbean                = 0x223D3A74B068ECA354DC385CE126833F9CF64915
 org.apache.xmlgraphics:batik-*:jar:1.7 = badSig
 
 org.apache.xmlgraphics          = \
+                                  0x5C9A30FF22B2C02F30261C305B93F1DF7CDB6DEA, \
                                   0x6BDACA2C0493CCA133B372D09C4F7E9D98B1CC53, \
                                   0x7FFB2D270C4DE3113518D09DE3E4404FCC31AE97, \
                                   0xAB6638CE472A499B3959ADA2F989A2E5C93C5700


### PR DESCRIPTION
Signature resolves to "Simon Steiner (CODE SIGNING KEY) <ssteiner@apache.org>"

Simon Steiner is listed as a committer on the xmlgraphics project:
https://people.apache.org/phonebook.html?uid=ssteiner

However, this signature is not found at https://people.apache.org/keys/group/xmlgraphics.asc

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
