### PR TITLE
new keys and more specific "noSig" for org.antlr

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -241,6 +241,41 @@
             <version>1.5-beta1</version>
         </dependency>
         <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>[3.5.2]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr3-maven-plugin</artifactId>
+            <version>[3.5.2]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>gunit</artifactId>
+            <version>[3.5.2]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>maven-gunit-plugin</artifactId>
+            <version>[3.5.2]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>stringtemplate</artifactId>
+            <version>[4.0.2]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-intellij-adaptor</artifactId>
+            <version>[0.1]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>[4.9.2]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-aar-maven-plugin</artifactId>
             <version>[1.7.9]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -369,8 +369,18 @@ msv                             = noSig
 ognl:ognl:(,3.0]                = noSig
 ognl                            = 0xE157EEB8D208EEB23F5723AC06F21382801CEF5F
 
-org.antlr:*:(,3.3]              = noSig
-org.antlr                       = 0xD54A395B5CF3F86EB45F6E426B1B008864323B92
+org.antlr:antlr:(,3.4-beta4]                  = noSig
+org.antlr:antlr-master:(,3.4-beta4]           = noSig
+org.antlr:antlr-runtime:(,3.4-beta4]          = noSig
+org.antlr:antlr3-maven-archetype:(,3.4-beta4] = noSig
+org.antlr:antlr3-maven-plugin:(,3.4-beta4]    = noSig
+org.antlr:gunit:(,3.4-beta4]                  = noSig
+org.antlr:maven-gunit-plugin:(,3.4-beta4]     = noSig
+org.antlr:stringtemplate                      = noSig
+org.antlr                       = \
+                                  0x842AFB86375D805422835BFD82B5574242C20D6F, \
+                                  0xB2D1AC7BE5A3EEB9773A49FE6EB9DE4D7E01B1E1, \
+                                  0xD54A395B5CF3F86EB45F6E426B1B008864323B92
 
 org.apache.ant                  = \
                                   0x06A228AAB83A18A8DF7B84B08614D6AB265B4C63, \


### PR DESCRIPTION
All artifacts and versions that do not have signatures are specifically added "noSig".
All other artifacts have PGP signatures.

The existing signature 6B1B008864323B92 resolves to "Terence Parr (ANTLR Project Lead) <parrt@antlr.org>".

The first new signature 6EB9DE4D7E01B1E1 resolves to "Terence Parr (ANTLR Author) <parrt@antlr.org>".

The other new signature 82B5574242C20D6F resolves to "Sam Harwell <sam@tunnelvisionlabs.com>", whose GitHub projects are antlr-related: https://github.com/sharwell

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
