### PR TITLE
new key for org.apache.commons:commons-math3

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -246,6 +246,11 @@
             <version>[1.7.9]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>[3.6.1]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>[4.5.13]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -93,6 +93,9 @@ commons-io                      = \
                                   0xCD5464315F0B98C77E6E8ECD9DAADC1C9FCC82D0, \
                                   0xD196A5E3E70732EEB2E5007F1861C322C56014B2
 
+org.apache.commons:commons-math3 = \
+                                  0x41A1A08C62FCA78B79D3081164A16FAAEC16A4BE
+
 commons-validator:*:(,1.3.0]    = noSig
 commons-validator:*:pom:1.3.1   = noSig
 commons-validator               = \


### PR DESCRIPTION
Signature resolves to "Evan Ward <evanward@apache.org>".

Evan Ward is listed as a committer on "commons":
https://people.apache.org/phonebook.html?uid=evanward

However, because this signature is not specifically listed, we are only applying to the "commons-math3" artifactId:
https://people.apache.org/keys/group/commons.asc

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
