### PR TITLE
new key for org.apache.tomcat.maven

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -309,6 +309,11 @@
             <version>[10.1.0-M2]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.tomcat.maven</groupId>
+            <artifactId>tomcat7-maven-plugin</artifactId>
+            <version>[2.2]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
             <version>[5.0.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -483,6 +483,8 @@ org.apache.tomcat.*             = \
                                   0x713DA88BE50911535FE716F5208B0AB1D63011C7, \
                                   0xA9C5DF4D22E99998D9875A5110C01C5A2F6059E7
 
+org.apache.tomcat.maven         = 0xF254B35617DC255D9344BCFA873A8E86B4372146
+
 org.apache.velocity:velocity:1.5 = noSig
 org.apache.velocity             = \
                                   0x7B9751FC3F01F134F476464CD0EB627D4885CED1, \


### PR DESCRIPTION
Signature resolves to "Olivier Lamy <olamy@apache.org>".

Olivier Lamy is listed as a committer on many projects, including "tomcat":
https://people.apache.org/phonebook.html?uid=olamy

However, because this signature is not specifically listed, we are only applying to the "org.apache.tomcat.maven" groupId:
https://people.apache.org/keys/group/tomcat.asc

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
