### PR TITLE
new key for org.eclipse.jdt.core.compiler

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -334,6 +334,11 @@
             <version>[3.3.0]</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <artifactId>ecj</artifactId>
+            <version>[4.6.1]</version>
+        </dependency>
+        <dependency>
             <groupId>org.libreoffice</groupId>
             <artifactId>libreoffice</artifactId>
             <version>[7.1.4]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -586,6 +586,8 @@ org.eclipse.aether              = \
 
 org.eclipse.core:resources:3.3.0-v20070604 = noSig
 
+org.eclipse.jdt.core.compiler   = 0x45DAD8AED069092BC7BE9843ECA081A9790D4FC4
+
 org.eclipse.jgit                = 0x7C669810892CBD3148FA92995B05CCDE140C2876
 
 org.eclipse.jetty               = 0x5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4


### PR DESCRIPTION
Signature resolves to "Ralph Schaer <ralphschaer@gmail.com>".

Ralph Schaer is listed as a developer in the project pom.xml:
https://repo1.maven.org/maven2/org/eclipse/jdt/core/compiler/ecj/4.6.1/ecj-4.6.1.pom

Ralph Schaer as a developer is also referenced in Eclipse bug #484004:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=484004

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
