### PR TITLE
new key for org.apache.poi and org.apache.xmlbeans:xmlbeans

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -289,6 +289,11 @@
             <version>[3.0.0-RC1]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>[5.0.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.taglibs</groupId>
             <artifactId>taglibs-standard-spec</artifactId>
             <version>[1.2.5]</version>
@@ -302,6 +307,11 @@
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
             <version>[10.1.0-M2]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlbeans</groupId>
+            <artifactId>xmlbeans</artifactId>
+            <version>[5.0.1]</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -468,6 +468,8 @@ org.apache.maven.*              = \
 
 org.apache.pdfbox               = 0xA602970FE1BF5C9C8A9491B97A3C9FE21DFDBF44
 
+org.apache.poi                  = 0x24188560524400B142BE3386A93E1C4B26062CE3
+
 org.apache.struts               = 0xCE4460D20B66C7E1687475BAD388AD829F3E96F7
 
 org.apache.struts:struts-core:pom:1.3.8   = badSig
@@ -491,6 +493,9 @@ org.apache.ws.commons           = 0x69AFC3E565D7C4FFC6B0C733612333A3DE240A64
 org.apache.ws.xmlschema         = 0x51B52DC5DD452F92BE342CC2858FC4C4F43856A3
 
 org.apache.xbean                = 0x223D3A74B068ECA354DC385CE126833F9CF64915
+
+org.apache.xmlbeans:xmlbeans:[3.0.0,) = \
+                                  0x24188560524400B142BE3386A93E1C4B26062CE3
 
 org.apache.xmlgraphics:batik-*:jar:1.7 = badSig
 


### PR DESCRIPTION
This signature is listed as "ASF ID: kiwiwings" at https://people.apache.org/keys/group/poi.asc

org.apache.xmlbeans:xmlbeans has been part of POI since version 3.0.0, while older versions and other artifacts do not seem as closely related to POI.

We have only added the signature for the latest release of org.apache.xmlbeans:xmlbeans, signatures for older versions can be added on an as-needed basis.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
