### PR TITLE
new key for org.eclipse.jdt:ecj

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -349,6 +349,11 @@
             <version>[3.3.0]</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>ecj</artifactId>
+            <version>[3.26.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jdt.core.compiler</groupId>
             <artifactId>ecj</artifactId>
             <version>[4.6.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -593,6 +593,8 @@ org.eclipse.aether              = \
 
 org.eclipse.core:resources:3.3.0-v20070604 = noSig
 
+org.eclipse.jdt:ecj             = 0x462E0F0FD51D11AB1FF74EC77AA1F762B414F87E
+
 org.eclipse.jdt.core.compiler   = 0x45DAD8AED069092BC7BE9843ECA081A9790D4FC4
 
 org.eclipse.jgit                = 0x7C669810892CBD3148FA92995B05CCDE140C2876


### PR DESCRIPTION
Signature resolves to "Eclipse JDT Project <jdt-dev@eclipse.org>".

There are many artifacts in the "org.eclipse.jdt" groupId.  We have only included the artifactId we require, and we do not want to assume the signatures of other artifacts.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
