### PR TITLE
new keys for Jakarta JSTL

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -125,6 +125,21 @@
             <version>[1.0.1]</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <version>[4.0.0]</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>[5.0.0]</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>[2.0.0]</version>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>[2.1.1]</version>
@@ -352,6 +367,11 @@
             <groupId>org.eclipse.jdt.core.compiler</groupId>
             <artifactId>ecj</artifactId>
             <version>[4.6.1]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <version>[2.0.0]</version>
         </dependency>
         <dependency>
             <groupId>org.jfree</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -257,7 +257,13 @@ isorelax                        = noSig
 jakarta.activation              = 0xCAE38BC93D90B852D88465DD3A1959EEF8726006 # master key
 jakarta.annotation              = 0xF6CE460FDBE1AABD1A96456737ECFC571637667C # master key
 
+jakarta.el                      = 0x7AA34304FF173025AA394C7C2C026998703FFA67
+
 jakarta.jws                     = 0xCB3B6379F3D113FA3D7CB45F2776BC4F5165A5EB
+
+jakarta.servlet                 = 0xAFEDF1B56323F5291EC3ED2E260E672C0D78E9B0
+
+jakarta.servlet.jsp.jstl        = 0x7BE1BB0B4DE4CFB872E90E51296863EC7506AB74
 
 jakarta.transaction             = 0x1A2A6D7F079CF627566ABD869B26CED3E3BA51C3
 
@@ -617,6 +623,9 @@ org.glassfish.ha                = 0x5D5E2FA03AA30ED092A50117FD8776B8DA948C3D
 org.glassfish.jaxb              = 0x06A4D15D9FA796BA5DECF592CE8B1D1D2530EDC5
 
 org.glassfish.pfl               = 0x98B8EC91D603095B68BB257D5E06B3EFC614EB37
+
+org.glassfish.web:jakarta.servlet.jsp.jstl = \
+                                  0x7BE1BB0B4DE4CFB872E90E51296863EC7506AB74
 
 org.hamcrest:hamcrest-core:1.1  = noSig
 org.hamcrest                    = \


### PR DESCRIPTION
Signature 2C026998703FFA67 resolves to "Eclipse Project for Expression Language <el-dev@eclipse.org>".

Signature 260E672C0D78E9B0 resolves to "Eclipse Project for Servlet <servlet-dev@eclipse.org>".

Signature 296863EC7506AB74 resolves to "Eclipse Project for JSTL <jstl-dev@eclipse.org>".

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
