### PR TITLE
new key for org.codehaus.mojo:properties-maven-plugin

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -324,6 +324,11 @@
             <version>[1.14]</version>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>properties-maven-plugin</artifactId>
+            <version>[1.0.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-component-annotations</artifactId>
             <version>[2.1.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -533,6 +533,9 @@ org.codehaus.groovy             = \
 org.codehaus.jackson = noSig
 
 
+org.codehaus.mojo:properties-maven-plugin = \
+                                  0xD433F9C895710DB8AB087FA6B7C3B43D18EAA8B7
+
 org.codehaus.plexus:plexus-archiver:[1.0-alpha-3,1.0-alpha-12] = noSig
 org.codehaus.plexus:plexus-container-default:(,1.5.2] = noSig
 org.codehaus.plexus:plexus-classworlds:(,2.2.2] = noSig


### PR DESCRIPTION
I am unable to find any meaningful information to verify the B7C3B43D18EAA8B7 signature.  However, this mapping entry will still ensure future releases are signed by the same key as the first and only release.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
