### PR TITLE
new keys for org.lz4

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -374,6 +374,11 @@
             <version>[2.7.2]</version>
         </dependency>
         <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>[1.8.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.ostermiller</groupId>
             <artifactId>utils</artifactId>
             <!-- Cannot use "[1.07.00]" due to missing maven-metadata.xml at

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -659,6 +659,9 @@ org.libreoffice                 = 0xC2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3
 org.lucee:xalan                 = 0x26BA3E8B6A185070F538B1C15C3F925A060D5930
 org.lucee:xalan-serializer      = 0x26BA3E8B6A185070F538B1C15C3F925A060D5930
 
+org.lz4:*:1.8.0                 = noKey # 0x55ABBEF06CF6277A23B1D3A21993B355097C8B5A not found in keyservers
+org.lz4                         = 0x55EC199CAA5FFDB20C4D825E1F318213E56E467A
+
 org.mockito                     = \
                                   0x147B691A19097624902F4EA9689CBE64F4BC997F, \
                                   0xCC4483CD6A3EB2939B948667A1B4460D8BA7B9AF


### PR DESCRIPTION
Versions 1.7.1 and below have a signature that resolves to "Rei Odaira (lz4-java maintainer) <Rei.Odaira@gmail.com>".

Versions 1.8.0, the current latest release, has a signature that is not found in any of the public keyservers so is marked "noKey".

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
