### PR TITLE
new key for com.hynnet:jacob

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -67,6 +67,11 @@
             <version>[3.17.3]</version>
         </dependency>
         <dependency>
+            <groupId>com.hynnet</groupId>
+            <artifactId>jacob</artifactId>
+            <version>[1.18]</version>
+        </dependency>
+        <dependency>
             <groupId>com.pragmatickm</groupId>
             <artifactId>pragmatickm-parent</artifactId>
             <version>[1.10.2]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -159,6 +159,8 @@ com.google.*                    = \
 
 com.hp.hpl.jena                 = noSig
 
+com.hynnet:jacob                = 0x1E31CD81EFF9A0D43E59BA026D346B32FC3FC9CF
+
 com.intellij                    = 0x746B94E2EB774FD0BAD985DC53FBF61FE95B3726
 
 com.ibm.icu:icu4j:(,4.0.1]     = noSig


### PR DESCRIPTION
Signature resolves to "hynnet.com (hynnet.com) <hynnet@hynnet.com>".

There are many artifacts in the "com.hynnet" groupId.  We have only included the artifactId we require, and we do not want to assume the signatures of other artifacts.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
