### PR TITLE
new key for com.github.virtuald

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -62,6 +62,11 @@
             <version>[1.1.0]</version>
         </dependency>
         <dependency>
+            <groupId>com.github.virtuald</groupId>
+            <artifactId>curvesapi</artifactId>
+            <version>[1.06]</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>[3.17.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -128,6 +128,8 @@ com.github.spotbugs             = \
                                   0x9857C388D7D1D9D031274CD0A5DEF5A76F94A471, \
                                   0xEAD73BAFA397701858506C241756B920EECF0E90
 
+com.github.virtuald             = 0x1D657819C1D8DE42D96881C1D5C6377EDE50786B
+
 com.google.code.findbugs:jsr305:(,2.0.1] = noSig
 com.google.code.findbugs        = 0x7616EB882DAF57A11477AAF559A252FB1199D873
 


### PR DESCRIPTION
The signature does not provide any name or email address.

However, I do find the project at GitHub at https://github.com/virtuald/curvesapi

This is the first and only artifactId within com.github.virtuald published, so we have added the key to verify future artifacts are signed with the same key.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
