### PR TITLE
new key for com.google.errorprone:error_prone_annotations

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -67,6 +67,11 @@
             <version>[1.06]</version>
         </dependency>
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>[2.7.1]</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>[3.17.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -132,6 +132,8 @@ com.google.code.findbugs        = 0x7616EB882DAF57A11477AAF559A252FB1199D873
 
 com.googlecode.javaewah        = 0x015479E1055341431B4545AB72475FD306B9CAB7
 
+com.google.errorprone:error_prone_annotations = \
+                                  0x5CE325996A35213326AE2C68912D2C0ECCDA55C0
 com.google.errorprone           = \
                                   0x56053CEDBA17E065DE7FB97BEBA8E97B15086E24, \
                                   0x7615AD56144DF2376F49D98B1669C4BB543E0445, \


### PR DESCRIPTION
The signature does not resolve to any name or email address, so we have only added the key to this specific artifactId

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
