### PR TITLE
new key for org.apache.santuario

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -294,6 +294,11 @@
             <version>[5.0.0]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.santuario</groupId>
+            <artifactId>xmlsec</artifactId>
+            <version>[2.2.2]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.taglibs</groupId>
             <artifactId>taglibs-standard-spec</artifactId>
             <version>[1.2.5]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -470,6 +470,8 @@ org.apache.pdfbox               = 0xA602970FE1BF5C9C8A9491B97A3C9FE21DFDBF44
 
 org.apache.poi                  = 0x24188560524400B142BE3386A93E1C4B26062CE3
 
+org.apache.santuario            = 0xDB45ECD19B97514F727105AE67BF80B10AD53983
+
 org.apache.struts               = 0xCE4460D20B66C7E1687475BAD388AD829F3E96F7
 
 org.apache.struts:struts-core:pom:1.3.8   = badSig


### PR DESCRIPTION
This signature is listed as "ASF ID: coheigea" at https://people.apache.org/keys/group/santuario.asc

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
