### PR TITLE
Fixed sorting of keys from PR #217

### DIFF
--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -93,9 +93,6 @@ commons-io                      = \
                                   0xCD5464315F0B98C77E6E8ECD9DAADC1C9FCC82D0, \
                                   0xD196A5E3E70732EEB2E5007F1861C322C56014B2
 
-org.apache.commons:commons-math3 = \
-                                  0x41A1A08C62FCA78B79D3081164A16FAAEC16A4BE
-
 commons-validator:*:(,1.3.0]    = noSig
 commons-validator:*:pom:1.3.1   = noSig
 commons-validator               = \
@@ -399,6 +396,8 @@ org.apache.axis2                = 0x2D3C43AC36E5BCFC9696F996CE13E82AEE08B906
 
 org.apache.bcel                 = 0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB
 
+org.apache.commons:commons-math3 = \
+                                  0x41A1A08C62FCA78B79D3081164A16FAAEC16A4BE
 org.apache.commons              = \
                                   0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB, \
                                   0x636DE9055C4C75C7BD9830771241BC872C5E4EC0, \


### PR DESCRIPTION
This fixes the ordering of keys in PR #217: https://github.com/s4u/pgp-keys-map/pull/217

---

Signature resolves to "Evan Ward <evanward@apache.org>".

Evan Ward is listed as a committer on "commons":
https://people.apache.org/phonebook.html?uid=evanward

However, because this signature is not specifically listed, we are only applying to the "commons-math3" artifactId:
https://people.apache.org/keys/group/commons.asc

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
