### PR TITLE
Avoid org.lz4:lz4-java:1.8.0 that requires "noKey" - builds failing

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -431,7 +431,11 @@
         <dependency>
             <groupId>org.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>[1.8.0]</version>
+            <!--
+                Avoid 1.8.0 that requires "noKey", since "noKey" currently fails builds when any keyserver is down:
+                https://github.com/s4u/pgpverify-maven-plugin/issues/305
+            -->
+            <version>(,1.8.0),(1.8.0,)</version>
         </dependency>
         <dependency>
             <groupId>org.ostermiller</groupId>


### PR DESCRIPTION
pgp.mit.edu is down again.  Perhaps 1.8.0 can be used by the tests again once https://github.com/s4u/pgpverify-maven-plugin/issues/305 is solved.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
