### PR TITLE
Changed test to artifact that will stay at "com.aoindustries"

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -58,8 +58,9 @@
         </dependency>
         <dependency>
             <groupId>com.aoindustries</groupId>
-            <artifactId>noc-monitor-portmon</artifactId>
-            <version>[1.1.0]</version>
+            <artifactId>javatator</artifactId>
+            <version>[0.5.0]</version>
+            <type>war</type>
         </dependency>
         <dependency>
             <groupId>com.github.virtuald</groupId>


### PR DESCRIPTION
We will be relocating noc-monitor-portmon to a different groupId,
while javatator will stay at com.aoindustries.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
