### PR TITLE
new keys and noSig for log4j:log4j:1.2.15-1.2.16

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -263,6 +263,11 @@
             <version>[4.13.2]</version>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>[1.2.17]</version>
+        </dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>[8.0.26]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -346,6 +346,9 @@ junit                           = \
                                   0xFF6E2C001948C5F2F38B0CC385911F425EC61B51
 
 log4j:log4j:(,1.2.14]           = noSig
+log4j:log4j:pom:1.2.15          = noSig
+log4j:log4j:1.2.15              = 0xA1A2B5546D4331B2A41E1C07BE16C95D2E114322
+log4j:log4j:1.2.16              = 0x28F5F55439C71A8F2B1E58C4D3EC499070C9C3D0
 log4j                           = 0x9D23533896A9784703585B6286E02C5A42196CA8
 
 logkit                          = noSig


### PR DESCRIPTION
Both signatures are listed as "ASF ID: carnold" at https://people.apache.org/keys/committer/carnold

For version 1.2.15, the pom artifact is not signed so marked "noSig".
The other artifacts are signed.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
