### PR TITLE
noSig for com.thoughtworks.qdox <= 1.12

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -125,6 +125,11 @@
             <version>[3.0.1]</version>
         </dependency>
         <dependency>
+            <groupId>com.thoughtworks.qdox</groupId>
+            <artifactId>qdox</artifactId>
+            <version>[2.0.0]</version>
+        </dependency>
+        <dependency>
             <groupId>com.trilead</groupId>
             <artifactId>trilead-ssh2</artifactId>
             <version>[1.0.0-build222]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -230,6 +230,7 @@ com.sun.xml.ws                  = \
 
 com.trilead                     = 0x4D90040F09023A4A74DF2F54ABAAE54F37E6F8E1
 
+com.thoughtworks.qdox:*:(,1.12] = noSig
 com.thoughtworks.*              = \
                                   0x050A37A2E0577F4BAA095B52602EC18D20C4661C, \
                                   0x31FAE244A81D64507B47182E1B2718089CE964B8, \


### PR DESCRIPTION
Older versions of com.thoughtworks.qdox:qdox, from 1.12 and before, are not signed.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
