### PR TITLE
noSig for com.servlets

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -105,6 +105,11 @@
             <type>pom</type>
         </dependency>
         <dependency>
+            <groupId>com.servlets</groupId>
+            <artifactId>cos</artifactId>
+            <version>[09May2002]</version>
+        </dependency>
+        <dependency>
             <groupId>com.stripe</groupId>
             <artifactId>stripe-java</artifactId>
             <version>[20.68.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -194,6 +194,8 @@ com.puppycrawl.tools            = 0x06D34ED6FF73DE368A772A781063FE98BCECB758
 
 com.semanticcms                 = 0x3FF945C37048D113E997AEC7CE70AA9A5BD10E01
 
+com.servlets                    = noSig
+
 com.stripe:stripe-java          = 0xC33033E4B583FE612EDE877C05D02D3D57ABFF46
 
 com.sun.activation              = 0xCAE38BC93D90B852D88465DD3A1959EEF8726006


### PR DESCRIPTION
All artifacts in com.servlets groupId are unsigned.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
