### PR TITLE
new keys for javax.transaction

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -208,6 +208,21 @@
             <version>1.5rc3</version>
         </dependency>
         <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>javax.transaction-api</artifactId>
+            <version>[1.3]</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <version>[1.1]</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>transaction-api</artifactId>
+            <version>[1.1-rev-1]</version>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>[2.1.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -317,6 +317,12 @@ javax.mail                      = noSig
 javax.servlet:servlet-api:2.3   = noSig
 javax.servlet                   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 
+javax.transaction:javax.transaction-api:(,1.2] = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
+javax.transaction:javax.transaction-api:[1.3,) = 0xA4664D6FA36D88138DEF3D1AA077240BC1422FB9
+javax.transaction:jta                          = noSig
+javax.transaction:transaction-api:1.1          = noSig
+javax.transaction:transaction-api:1.1-rev-1    = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF88103E
+
 javax.validation                = noSig
 
 javax.ws.rs:javax.ws.rs-api:(,2.1]   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4


### PR DESCRIPTION
Mapped all artifacts in "javax.transaction" groupId.

New keys resolve to:

1) java_re <GF_RELEASE_WW@oracle.com>

2) Stephen Felts <stephen.felts@oracle.com>

3) Maven Central Java.net import (Used to sign artifacts imported from Java.net repos) <repository@sonatype.com>

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
