### PR TITLE
new key for com.google.googlejavaformat

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -78,6 +78,11 @@
             <version>[2.8.1]</version>
         </dependency>
         <dependency>
+            <groupId>com.google.googlejavaformat</groupId>
+            <artifactId>google-java-format</artifactId>
+            <version>[1.11.0]</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>[3.17.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -150,6 +150,8 @@ com.google.collections:google-collections:1.0 = noSig
 
 com.google.code.gson            = 0xC7BE5BCC9FEC15518CFDA882B0F3710FA64900E7
 
+com.google.googlejavaformat     = 0xE77417AC194160A3FABD04969A259C7EE636C5ED
+
 com.google.protobuf:protobuf-java = \
                                   0x696B6199A2A9D8C29CE78CC0D041CAD2E452550F
 


### PR DESCRIPTION
Signature resolves to "Liam Miller-Cushon <cushon@google.com>".

This signature is already present in the map for the "com.google.errorprone" groupId.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
