### PR TITLE
Added keys for jline

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -273,6 +273,11 @@
             <version>[1.0.2]</version>
         </dependency>
         <dependency>
+            <groupId>jline</groupId>
+            <artifactId>jline</artifactId>
+            <version>[3.0.0.M1]</version>
+        </dependency>
+        <dependency>
             <groupId>eu.medsea.mimeutil</groupId>
             <artifactId>mime-util</artifactId>
             <version>[2.1.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -355,7 +355,11 @@ jgraph                          = noSig
 
 jsch                            = noSig
 
-jline                           = noSig
+jline:jline:(,0.9.94]           = noSig
+jline:jline:1.0                 = 0xC68C38E51FC511BE6E39D5BF068EC5F03836CB2E
+jline:jline:[2.6,)              = \
+                                  0x045B3D6AE9500CE0F930DFE48D948CAF35543C27, \
+                                  0xEA23DB1360D9029481E7F2EFECDFEA3CB4493B94
 
 joda-time                       = 0xB41089A2DA79B0FA5810252872385FF0AF338D52
 


### PR DESCRIPTION
Versions before 1.0 are unsigned.

Version 1.0 signed by "Douglas Campos <qmx@qmx.me>", and this key was revoked 2012-04-24.

Newer versions are signed by:

1) "Jason Dillon (Maven Codesign) <jason@planet57.com>" - This key is already in the map for several different artifacts.

2) "Guillaume Nodet <gnodet@apache.org>" - This key is also already in the map for several different artifacts.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
