### PR TITLE
new keys for javassist

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -599,6 +599,16 @@
             <version>[1.5.3]</version>
         </dependency>
         <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>[3.12.1.GA]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>[3.28.0-GA]</version>
+        </dependency>
+        <dependency>
             <groupId>org.jibx</groupId>
             <artifactId>jibx-bind</artifactId>
             <version>[1.3.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -757,7 +757,13 @@ org.jfree:jfreechart            = 0x1A6782E4EBF49045C8040D1B93157E22A3A5461C
 
 org.javaruntype                 = 0x839323A4780D5BF9A6978970152888E10EF880B3
 
-org.javassist                   = 0x666A4692CE11B7B3F4EB7B3410066A9707090CF9
+javassist                       = noSig
+org.javassist:*:3.18.1-Beta1    = noSig
+org.javassist:*:3.22.0-CR2      = noSig
+org.javassist                   = \
+                                  0x666A4692CE11B7B3F4EB7B3410066A9707090CF9, \
+                                  0xE3E28CF9BAD6548DA332530069DA36AE31C5C4B3, \
+                                  0xE5C3B1929191DF06136CCB2B164779204E106A76
 
 org.jdom:jdom:1.1               = noSig
 org.jdom                        = \


### PR DESCRIPTION
Added noSig for older "javassist" groupId.

Found a couple versions noSig for newer "org.javassist" groupId.

Added keys for newer "org.javassist" groupId:
1) "Andrew Dinn (JBoss Developer) <adinn@redhat.com>"
2) "Shigeru Chiba (Javassist Developer) <chiba@javassist.org>"

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
