### PR TITLE
Additional key for protobuf-java

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>[3.17.3]</version>
+            <version>[3.18.0]</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.maven-scm-provider-svnjava</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -155,7 +155,8 @@ com.google.code.gson            = 0xC7BE5BCC9FEC15518CFDA882B0F3710FA64900E7
 com.google.googlejavaformat     = 0xE77417AC194160A3FABD04969A259C7EE636C5ED
 
 com.google.protobuf:protobuf-java = \
-                                  0x696B6199A2A9D8C29CE78CC0D041CAD2E452550F
+                                  0x696B6199A2A9D8C29CE78CC0D041CAD2E452550F, \
+                                  0xE7D86375B2E8A347EBCA8DA9C2E8DCFEA41DA422
 
 com.google.*                    = \
                                   0x1616273079FE63E31C938F10F0DF21D1D0A3C384, \


### PR DESCRIPTION
Signature resolves to "Bo Yang <teboring@google.com>".

Although a different GPG key, this matches the identity of the 3.18.0 release "TeBoring":
https://github.com/protocolbuffers/protobuf/releases/tag/v3.18.0
https://github.com/TeBoring