### PR TITLE
Additional keys for com.github.spotbugs and related dependencies

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -73,6 +73,11 @@
             <type>war</type>
         </dependency>
         <dependency>
+            <groupId>com.github.javaparser</groupId>
+            <artifactId>javaparser-core</artifactId>
+            <version>[3.23.0]</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.virtuald</groupId>
             <artifactId>curvesapi</artifactId>
             <version>[1.06]</version>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -890,7 +890,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.3.0</version>
+                <version>4.4.1</version>
             </plugin>
         </plugins>
     </build>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -123,10 +123,13 @@ com.fasterxml.*                 = \
                                   0x064F04959CD99ACCC4DFB54C9CD8549ACF9BD0CE, \
                                   0x8A10792983023D5D14C93B488D7F1BEC1E2ECAE7
 
-com.github.javaparser           = 0x8756C4F765C9AC3CB6B85D62379CE192D401AB61
+com.github.javaparser           = \
+                                  0x8756C4F765C9AC3CB6B85D62379CE192D401AB61, \
+                                  0xA55830120AED177E1AA4F66A431B8F80403A7DC1
 
 com.github.spotbugs             = \
                                   0x3B9CD44BEEDFBDFABA22717BEEA8F6DF3031CD02, \
+                                  0x787F7A150BC86005D13BE40BE5B9E4A8C7850FE7, \
                                   0x9857C388D7D1D9D031274CD0A5DEF5A76F94A471, \
                                   0xEAD73BAFA397701858506C241756B920EECF0E90
 


### PR DESCRIPTION
This is to resolve the build failure of 85ae9af16f79b951b262164e9869f5dbf0d0e731

com.github.spotbugs
---
Signature resolves to "Jeremy Landis (hazendaz) <jeremylandis@hotmail.com>".

This matches the GitHub identity "hazendaz" of the commit associated with the most recent release:
https://github.com/spotbugs/spotbugs-maven-plugin/commit/741f662a0d32ca1d4307d5bf47f75424893104ff

The commits are not signed, however, so we cannot compare any specific PGP keys.

com.github.javaparser dependency
---
Signature resolves to "Roger Howell <MysterAitch@users.noreply.github.com>".

This matches the GitHub identity "MysterAitch" of the commit associated with the most recent release:
https://github.com/javaparser/javaparser/commit/67d7edf70b7cb03a2c717b74b5ed23c640de22f3

The commits are not signed, however, so we cannot compare any specific PGP keys.