### PR TITLE
new keys for javax.servlet.jsp

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -223,6 +223,16 @@
             <version>1.5rc3</version>
         </dependency>
         <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>el-api</artifactId>
+            <version>[2.2.1-b04]</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>[3.0.1-b06]</version>
+        </dependency>
+        <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
             <version>[1.3]</version>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -226,6 +226,13 @@
             <groupId>javax.el</groupId>
             <artifactId>el-api</artifactId>
             <version>[2.2.1-b04]</version>
+            <!-- Exclude dependencies of this older artifact to avoid conflicts -->
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
@@ -248,6 +255,23 @@
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>3.0-alpha-1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>jsp-api</artifactId>
+            <version>2.2.1-b03</version>
+            <!-- Exclude dependencies of this older artifact to avoid conflicts -->
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>javax.servlet.jsp-api</artifactId>
+            <version>2.3.3</version>
         </dependency>
         <dependency>
             <groupId>javax.transaction</groupId>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -233,6 +233,23 @@
             <version>[3.0.1-b06]</version>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>[4.0.1]</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+            <!-- Cannot use "[1.2]" due to incomplete maven-metadata.xml at
+                 https://repo1.maven.org/maven2/javax/servlet/jstl/maven-metadata.xml -->
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>3.0-alpha-1</version>
+        </dependency>
+        <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
             <version>[1.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -328,7 +328,11 @@ javax.jws                       = 0x70CD19BFD9F6C330027D6F260315BFB7970A144F
 
 javax.mail                      = noSig
 
-javax.servlet:servlet-api:2.3   = noSig
+javax.servlet:jsp-api           = noSig
+javax.servlet:jstl              = noSig
+javax.servlet:servlet-api       = noSig
+javax.servlet:servlet-api:3.0-alpha-1 = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF88103E
+javax.servlet:sip-api           = noSig
 javax.servlet                   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 
 javax.transaction:javax.transaction-api:(,1.2] = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -313,6 +313,12 @@ javax.annotation                = noSig
 
 javax.enterprise                = 0xB1FC0E1FA329669191F8306F5BCEE695141E6086
 
+javax.el:el-api:1.0                     = noSig
+javax.el:el-api:[1.1,)                  = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF88103E
+javax.el:javax.el-api:1.1.2             = 0x609ED37905811AF8DE6D5F218B57C0E09D80277B
+javax.el:javax.el-api:[2.2.1,3.0.1-b04] = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
+javax.el:javax.el-api:[3.0.1-b06,)      = 0x03D580C97BB14418E1C9E922D3B7479720EE1AF8
+
 javax.inject                    = noSig
 
 javax.jdo:jdo2-api:(,2.0]       = noSig

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -335,6 +335,10 @@ javax.servlet:servlet-api:3.0-alpha-1 = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF8810
 javax.servlet:sip-api           = noSig
 javax.servlet                   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 
+javax.servlet.jsp:jsp-api:(,2.1]       = noSig
+javax.servlet.jsp:jsp-api:[2.1-rev-1,) = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF88103E
+javax.servlet.jsp                      = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
+
 javax.transaction:javax.transaction-api:(,1.2] = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 javax.transaction:javax.transaction-api:[1.3,) = 0xA4664D6FA36D88138DEF3D1AA077240BC1422FB9
 javax.transaction:jta                          = noSig


### PR DESCRIPTION
Thoroughly mapped all artifacts and versions in the javax.servlet.jsp groupId.

The two signatures are the same as seen on other Java EE artifacts.