### PR TITLE
new keys for javax.websocket

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -238,6 +238,11 @@
             <version>[1.1-rev-1]</version>
         </dependency>
         <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>[1.1]</version>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>[2.1.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -333,6 +333,10 @@ javax.transaction:transaction-api:1.1-rev-1    = 0x69859CF50A3C1EB40A90D5FD2D664
 
 javax.validation                = noSig
 
+javax.websocket                 = \
+                                  0x4F7E32D440EF90A83011A8FC6425559C47CC79C4, \
+                                  0xF97C2E386E2C4EFC7C3F98EE2D910134368593F3
+
 javax.ws.rs:javax.ws.rs-api:(,2.1]   = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 javax.ws.rs:javax.ws.rs-api:[2.1.1,) = 0x4BD9AEC34B75BE14431C8878160A876EB62C9DBE
 


### PR DESCRIPTION
The older artifacts use the same signing key as many other Java EE artifacts.

The signature of the newer versions resolves to "Jersey Robot <jerseyrobot@java.net>".
This key is also already in the map for "com.sun.jersey".

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
