### PR TITLE
new key for org.codehaus.plexus:plexus-sec-dispatcher

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -624,6 +624,11 @@
             <version>[2.1.0]</version>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-sec-dispatcher</artifactId>
+            <version>[2.0]</version>
+        </dependency>
+        <dependency>
             <!-- In version 1.5.1, only sources are signed -->
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -697,6 +697,7 @@ org.codehaus.plexus:plexus-mail-sender-api = noSig
 org.codehaus.plexus:plexus-mail-sender-javamail = noSig
 org.codehaus.plexus:plexus-mail-sender-simple = noSig
 org.codehaus.plexus:plexus-resources:[1.0-alpha-4,1.0-alpha-5] = noSig
+org.codehaus.plexus:plexus-sec-dispatcher = 0x2BE13D052E9AA567D657D9791FD507154FB9BA39
 org.codehaus.plexus:plexus-utils:jar:sources:1.5.1 = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF88103E
 org.codehaus.plexus:plexus-utils:(,2.0.2] = noSig
 org.codehaus.plexus:plexus-velocity:(,1.1.8] = noSig


### PR DESCRIPTION
Signature resolves to "Tamás Cservenák <tamas@cservenak.net>".

This matches the GitHub identity "cstamas" of the commit associated with the most recent release:
https://github.com/codehaus-plexus/plexus-sec-dispatcher/commit/0bab9aa096c411973ce3d48771a8fe735cafd917

The commits are not signed, however, so we cannot compare any specific PGP keys.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
