### PR TITLE
new key for javax.annotation

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -228,6 +228,11 @@
             <version>1.5rc3</version>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>[1.3.2]</version>
+        </dependency>
+        <dependency>
             <groupId>javax.el</groupId>
             <artifactId>el-api</artifactId>
             <version>[2.2.1-b04]</version>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.stripe</groupId>
             <artifactId>stripe-java</artifactId>
-            <version>[20.77.0]</version>
+            <version>[20.79.0]</version>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -781,7 +781,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>[3.8.2]</version>
+            <version>[3.8.3]</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -312,7 +312,8 @@ jalopy                          = noSig
 javax.activation:activation     = noSig
 javax.activation                = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 
-javax.annotation                = noSig
+javax.annotation:jsr250-api     = noSig
+javax.annotation                = 0x4F7E32D440EF90A83011A8FC6425559C47CC79C4
 
 javax.enterprise                = 0xB1FC0E1FA329669191F8306F5BCEE695141E6086
 


### PR DESCRIPTION
This is the same signature as already in the map for many other Java EE artifacts.

This resolves the build error in #362