### PR TITLE
Additional key for com.github.javaparser

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>[3.23.0]</version>
+            <version>[3.23.1]</version>
         </dependency>
         <dependency>
             <groupId>com.github.virtuald</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -124,6 +124,7 @@ com.fasterxml.*                 = \
                                   0x8A10792983023D5D14C93B488D7F1BEC1E2ECAE7
 
 com.github.javaparser           = \
+                                  0x253E8E4C6FB28D11748115C1249DEE8E2C07A0A2, \
                                   0x8756C4F765C9AC3CB6B85D62379CE192D401AB61, \
                                   0xA55830120AED177E1AA4F66A431B8F80403A7DC1
 


### PR DESCRIPTION
Signature resolves to "Roger Howell <MysterAitch@users.noreply.github.com>".

This matches the GitHub identity "MysterAitch" of the commit associated with the most recent release:
https://github.com/javaparser/javaparser/releases/tag/javaparser-parent-3.23.1
https://github.com/javaparser/javaparser/commit/95f1339b0aebb9e3b3c4c36f8a644dcd054dc62e
https://github.com/MysterAitch

The commits are not signed, however, so we cannot compare any specific PGP keys.
