### PR TITLE
Added mapping for xmlbeans-5.0.2

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -585,7 +585,7 @@
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>[5.0.1]</version>
+            <version>[5.0.2]</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -640,7 +640,8 @@ org.apache.xmlbeans:xmlbeans:[3.0.0,3.0.2] = \
 org.apache.xmlbeans:xmlbeans:3.1.0 = \
                                   0x6072A0C8CE08EAAABF39ED4F2D15E54A1556F3A4
 org.apache.xmlbeans:xmlbeans:[4.0.0,) = \
-                                  0x24188560524400B142BE3386A93E1C4B26062CE3
+                                  0x24188560524400B142BE3386A93E1C4B26062CE3, \
+                                  0x6BA4DA8B1C88A49428A29C3D0C69C1EF41181E13
 
 org.apache.xmlgraphics:batik-*:jar:1.7 = badSig
 


### PR DESCRIPTION
xmlbeans 5.0.2 has the same key as seen on versions 3.0.0 through 3.0.2

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
