### PR TITLE
Added mapping for poi-5.1.0

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -535,7 +535,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>[5.0.0]</version>
+            <version>[5.1.0]</version>
         </dependency>
         <dependency>
             <groupId>org.apache.santuario</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -595,7 +595,9 @@ org.apache.neethi               = 0x51B52DC5DD452F92BE342CC2858FC4C4F43856A3
 
 org.apache.pdfbox               = 0xA602970FE1BF5C9C8A9491B97A3C9FE21DFDBF44
 
-org.apache.poi                  = 0x24188560524400B142BE3386A93E1C4B26062CE3
+org.apache.poi                  = \
+                                  0x24188560524400B142BE3386A93E1C4B26062CE3, \
+                                  0x6BA4DA8B1C88A49428A29C3D0C69C1EF41181E13
 
 org.apache.santuario            = 0xDB45ECD19B97514F727105AE67BF80B10AD53983
 


### PR DESCRIPTION
poi 5.1.0 has the same key as the recent release of the related xmlbeans project,
which is also the same key used for previous xmlbeans releases.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
