### PR TITLE
new key for org.apache.directory.api

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -488,6 +488,11 @@
             <version>[3.6.1]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-asn1-api</artifactId>
+            <version>[2.1.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-activation_1.1_spec</artifactId>
             <version>[1.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -505,6 +505,8 @@ org.apache.commons              = \
 
 org.apache.cxf                  = 0x51B52DC5DD452F92BE342CC2858FC4C4F43856A3
 
+org.apache.directory.api        = 0x63CE676698B26D3A36D77527223BD93328686142
+
 org.apache.felix                = \
                                   0x1AA8CF92D409A73393D0B736BFF2EE42C8282E76, \
                                   0x605321BC2706D57CFC783D227AE9960C1F9C6B25, \


### PR DESCRIPTION
Signature resolves to "Stefan Seelmann (CODE SIGNING KEY) <seelmann@apache.org>".

Mr. Seelmann is listed as a contributor to the "directory" project at https://people.apache.org/committer-index.html

This signing key does not match that listed at https://people.apache.org/keys/committer/seelmann

I have sent an email to Mr. Seelmann, asking him to verify this key is his and to also update his keys listed at people.apache.org

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
