### PR TITLE
new key for org.apache.servicemix.bundles

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -543,6 +543,11 @@
             <version>[2.3.0]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.antlr</artifactId>
+            <version>[3.5.2_1]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-core</artifactId>
             <version>[2.5.27]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -606,6 +606,8 @@ org.apache.poi                  = \
 
 org.apache.santuario            = 0xDB45ECD19B97514F727105AE67BF80B10AD53983
 
+org.apache.servicemix.bundles   = 0x1AA8CF92D409A73393D0B736BFF2EE42C8282E76
+
 org.apache.struts               = \
                                   0xCE4460D20B66C7E1687475BAD388AD829F3E96F7, \
                                   0x0E008698344E62B90633B7C62841610663AFBB1F


### PR DESCRIPTION
Signature resolves to "Jean-Baptiste Onofré <jbonofre@apache.org>"

jbonofre@apache.org is listed as a contributor to the "servicemix" project at https://people.apache.org/committer-index.html

There is no specific key listed on people.apache.org, but this key matches that already in the map for the "felix" project, for which they are also listed as a contributor.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
