### PR TITLE
Additional key for org.apache.logging.log4j

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -563,6 +563,11 @@
             <version>[0.8.6]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>[2.17.1]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
             <version>[2.1.5]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -588,7 +588,9 @@ org.apache.james                = \
 
 org.apache.jackrabbit           = 0xEAA526B91DD83BA3E1B9636FA730529CA355A63E
 
-org.apache.logging.log4j        = 0x53C935821AA6A755BD337DB53595395EB3D8E1BA
+org.apache.logging.log4j        = \
+                                  0x53C935821AA6A755BD337DB53595395EB3D8E1BA, \
+                                  0x748F15B2CF9BA8F024155E6ED7C92B70FA1C814D
 
 org.apache.maven.wagon:*:1.0-beta-2 = noSig
 


### PR DESCRIPTION
Signature resolves to "Matthew Sicker (Signing Key) <mattsicker@apache.org>"

This signatures matches that listed at https://people.apache.org/keys/committer/mattsicker for ASF ID "mattsicker".

mattsicker is listed on the roster of the "logging" project at https://people.apache.org/phonebook.html?unix=logging

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
