### PR TITLE
Additional key for org.libreoffice

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -777,7 +777,7 @@
         <dependency>
             <groupId>org.libreoffice</groupId>
             <artifactId>libreoffice</artifactId>
-            <version>[7.2.3]</version>
+            <version>[7.2.5]</version>
         </dependency>
         <dependency>
             <groupId>org.lucee</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -923,7 +923,9 @@ org.jvnet.staxex                = 0x06A4D15D9FA796BA5DECF592CE8B1D1D2530EDC5, \
 
 org.kopitubruk.util             = 0xBED8150B4DF16120DEAFD461D90AF6F50CA9ADC1
 
-org.libreoffice                 = 0xC2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3
+org.libreoffice                 = \
+                                  0x1C67D33B45FF883CF72675872B72BCDB418E6BC6, \
+                                  0xC2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3
 
 org.liquibase                   = 0xBAF4CE3CC55E6523CF5881A78AFE608B21FE903C
 


### PR DESCRIPTION
Signature resolves to "Xisco Fauli <xiscofauli@libreoffice.org>"

Xisco Fauli is listed under libreoffice professional support at https://www.libreoffice.org/get-help/professional-support/

This PR includes the commit from #493 and resolves the build failure.  If you would prefer a single commit independent of #493, we can rebase.