### PR TITLE
Added "noSig" for older org.codehaus.groovy:groovy

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -679,6 +679,11 @@
             <version>[2.1.1]</version>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>[3.0.9]</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>buildnumber-maven-plugin</artifactId>
             <version>[3.0.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -725,6 +725,7 @@ org.codehaus.gmaven.*           = \
                                   0x045B3D6AE9500CE0F930DFE48D948CAF35543C27, \
                                   0x0DCF749D41A80E58041AAE1728F57F70167C0B3A
 
+org.codehaus.groovy:groovy:(,2.2.1] = noSig
 org.codehaus.groovy:groovy-all:(,2.2.1] = noSig
 org.codehaus.groovy             = \
                                   0x34441E504A937F43EB0DAEF96A65176A0FB1CD0B, \


### PR DESCRIPTION
Versions of org.codehaus.groovy:groovy 2.2.1 and below are not signed.

This resolves the dependency problem in #487  Please accept this PR then rebase #487

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
