### PR TITLE
New key for mysql-connector-java >= 8.0.28

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -448,7 +448,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>[8.0.27]</version>
+            <version>[8.0.28]</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -444,7 +444,8 @@ log4j                           = 0x9D23533896A9784703585B6286E02C5A42196CA8
 
 logkit                          = noSig
 
-mysql:mysql-connector-java      = 0xA4A9406876FCBD3C456770C88C718D3B5072E1F5
+mysql:mysql-connector-java:(,8.0.27] = 0xA4A9406876FCBD3C456770C88C718D3B5072E1F5
+mysql:mysql-connector-java:[8.0.28,) = 0x859BE8D7C586F538430B19C2467B942D3A79BD29
 
 nekohtml                        = noSig
 


### PR DESCRIPTION
Signature matches the new key for versions >= 8.0.28 documented at https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html

This builds upon and resolves the build error of PR #516