### PR TITLE
Additional key for org.apache.maven.*

### DIFF
--- a/org-apache-maven-plugins-test/pom.xml
+++ b/org-apache-maven-plugins-test/pom.xml
@@ -240,7 +240,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.6.4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -613,6 +613,7 @@ org.apache.maven.*              = \
                                   0x6E13156C0EE653F0B984663AB95BBD3FA43C4492, \
                                   0x7C9CFAF9C409737872FE044AF397D776F65C0178, \
                                   0x82C9EC0E52C47A936A849E0113D979595E6D01E1, \
+                                  0x84789D24DF77A32433CE1F079EB80E92EB2135B1, \
                                   0x849FB4F1AF3D17CDE4DE5E710704ADDF1D821345, \
                                   0x998AF0E2B935996F5CEBD56B9B1FDA9F3C062231, \
                                   0x9FFED7A118D45A44E4A1E47130E6F80434A72A7F, \


### PR DESCRIPTION
Signature resolves to "Slawomir Jaranowski <sjaranowski@apache.org>", and matches the key for "ASF ID: sjaranowski" at https://people.apache.org/keys/committer/sjaranowski

sjaranowski is listed as a contributor to "maven" at https://people.apache.org/phonebook.html?unix=maven

This builds on and resolves #518