### PR TITLE
Additional key for org.tmatesoft.*

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -881,7 +881,7 @@
         <dependency>
             <groupId>org.tmatesoft.svnkit</groupId>
             <artifactId>svnkit</artifactId>
-            <version>[1.10.3]</version>
+            <version>[1.10.4]</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -1028,7 +1028,9 @@ org.tmatesoft:svnkit                 = noSig
 org.tmatesoft.svnkit:svnkit:(,1.3.5] = noSig
 org.tmatesoft.svnkit:svnkit-javahl   = noSig
 org.tmatesoft.svnkit:trilead-ssh2    = noSig
-org.tmatesoft.*                 = 0x4D90040F09023A4A74DF2F54ABAAE54F37E6F8E1
+org.tmatesoft.*                 = \
+                                  0x36DFABCC7D7F357C9E04536D06294B7D913FB160, \
+                                  0x4D90040F09023A4A74DF2F54ABAAE54F37E6F8E1
 
 org.tukaani                     = 0x3690C240CE51B4670D30AD1C38EE757D69184620
 


### PR DESCRIPTION
Key exists in keys.openpgp.org but contains no user ID.  This basically means this commit blindly accepts this signing key without any meaningful identity verification.

I was unable to find any relevant GitHub for the project, only older versions and forks.

I do not find any signing key information on the download page at https://svnkit.com/download.php

I do not find any signing key information at the SVN tag at https://svn.svnkit.com/repos/svnkit/tags/1.10.4/

This resolves PR #528