### PR TITLE
Additional key and new test for org.vafer

### DIFF
--- a/org-apache-maven-plugins-test/pom.xml
+++ b/org-apache-maven-plugins-test/pom.xml
@@ -300,7 +300,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -980,6 +980,11 @@
             <version>[1.4.5]</version>
         </dependency>
         <dependency>
+            <groupId>org.vafer</groupId>
+            <artifactId>jdependency</artifactId>
+            <version>[2.7.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-ui</artifactId>
             <version>[1.13.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -1044,7 +1044,9 @@ org.tmatesoft.*                 = \
 
 org.tukaani                     = 0x3690C240CE51B4670D30AD1C38EE757D69184620
 
-org.vafer                       = 0x3909C28792327FAD38100EAF04633A577C200941
+org.vafer                       = \
+                                  0x3909C28792327FAD38100EAF04633A577C200941, \
+                                  0x79156E0351AF8604DE9B186B09A79E1E15A04694
 
 org.webjars:jquery-mobile       = 0x341C2AE47D5FF3A7EDFB5989E57A697A70CFE5F9
 org.webjars:jquery-ui           = 0x341C2AE47D5FF3A7EDFB5989E57A697A70CFE5F9


### PR DESCRIPTION
Signature resolves to "Torsten Curdt (Code Signing Key) <tcurdt@vafer.org>"

1) This is a different signing key than Mr. Curdt uses for Apache projects:
   https://people.apache.org/keys/committer/tcurdt

2) Cannot find any signing keys on his GitHub project or profile:
   https://github.com/tcurdt/jdependency
   https://github.com/tcurdt

Cannot specifically validate this PGP key, but the unverified identity does match the project well.

This builds on PR #609 and resolves its build error.