### PR TITLE
new key for org.codehaus.mojo:versions-maven-plugin

### DIFF
--- a/org-codehaus-mojo-test/pom.xml
+++ b/org-codehaus-mojo-test/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.9.0</version>
+                <version>2.10.0</version>
             </plugin>
         </plugins>
     </build>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -755,6 +755,9 @@ org.codehaus.mojo:buildnumber-maven-plugin = \
 org.codehaus.mojo:properties-maven-plugin = \
                                   0xD433F9C895710DB8AB087FA6B7C3B43D18EAA8B7
 
+org.codehaus.mojo:versions-maven-plugin = \
+                                  0xF1A427244820987F912BC6FE2B20ACA625D33968
+
 org.codehaus.plexus:plexus-archiver:[1.0-alpha-3,1.0-alpha-12] = noSig
 org.codehaus.plexus:plexus-container-default:(,1.5.2] = noSig
 org.codehaus.plexus:plexus-classworlds:(,2.2.2] = noSig


### PR DESCRIPTION
Signature resolves to "Stefan Seifert <stefan.seifert@diva-e.com>"

GitHub user "stefanseifert" is the committer on the release's associate tag:
https://github.com/mojohaus/versions-maven-plugin/releases
https://github.com/mojohaus/versions-maven-plugin/tree/versions-maven-plugin-2.10.0
https://github.com/stefanseifert

None of the GitHub commits appear to be signed, however, so cannot specifically validate this PGP key.

The identity, as much as we can verify, does look correct for this project.

This builds on PR #593 and resolves its build error.