### PR TITLE
new key for org.apache.groovy

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -1061,7 +1061,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.5.3.0</version>
+                <version>4.6.0.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -563,6 +563,11 @@
             <version>[4.5.13]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>[4.0.1]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>[4.4.15]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -584,6 +584,8 @@ org.apache.geronimo.specs       = \
                                   0x9056B710F1E332780DE7AF34CBAEBE39A46C4CA1, \
                                   0xEA23DB1360D9029481E7F2EFECDFEA3CB4493B94
 
+org.apache.groovy               = 0x34441E504A937F43EB0DAEF96A65176A0FB1CD0B
+
 org.apache.httpcomponents       = \
                                   0x0785B3EFF60B1B1BEA94E0BB7C25280EAE63EBE5, \
                                   0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB


### PR DESCRIPTION
Signature resolves to "Paul King <paulk@apache.org>"

PGP key matches ASF ID "paulk" at https://people.apache.org/keys/committer/paulk

paulk is listed on the roster for the groovy project at https://people.apache.org/phonebook.html?unix=groovy

This key is also already in the map for the related groupId "org.codehaus.groovy"

This builds on PR #604 and resolves its build error.