### PR TITLE
new keys for dependencies of svnkit-1.10.5

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -906,7 +906,7 @@
         <dependency>
             <groupId>org.tmatesoft.svnkit</groupId>
             <artifactId>svnkit</artifactId>
-            <version>[1.10.4]</version>
+            <version>[1.10.5]</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -456,6 +456,11 @@
             <version>[8.0.28]</version>
         </dependency>
         <dependency>
+            <groupId>net.i2p.crypto</groupId>
+            <artifactId>eddsa</artifactId>
+            <version>[0.3.0]</version>
+        </dependency>
+        <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
             <version>[5.11.0]</version>
@@ -611,6 +616,11 @@
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.antlr</artifactId>
             <version>[3.5.2_1]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-common</artifactId>
+            <version>[2.8.0]</version>
         </dependency>
         <dependency>
             <groupId>org.apache.struts</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -458,6 +458,8 @@ net.bytebuddy                   = \
                                   0xB4AC8CDC141AF0AE468D16921DA784CCB5C46DD5, \
                                   0xF42B96B8648B5C4A1C43A62FBB2914C1FA0811C3
 
+net.i2p.crypto                  = 0x43C79B4BBD131821E17D2CA77B2F0491728B8E02
+
 net.java.dev.javacc             = noSig
 
 net.java.dev.jna                = \
@@ -659,6 +661,8 @@ org.apache.poi                  = \
 org.apache.santuario            = 0xDB45ECD19B97514F727105AE67BF80B10AD53983
 
 org.apache.servicemix.bundles   = 0x1AA8CF92D409A73393D0B736BFF2EE42C8282E76
+
+org.apache.sshd                 = 0xDC98224C6421A7A5BB87F346ED2378CD09A08CDE
 
 org.apache.struts               = \
                                   0xCE4460D20B66C7E1687475BAD388AD829F3E96F7, \


### PR DESCRIPTION
net.i2p.crypto
---
Signature resolves to "str4d (Package signing) <str4d@mail.i2p>"

"str4d" is listed as a "Release Manager Alternates" at https://geti2p.net/en/contact

GitHub user "str4d" owns the repository related to this project:
https://github.com/str4d/ed25519-java/releases/tag/v0.3.0

org.apache.sshd
---
Signature resolves to "Guillaume Nodet (CODE SIGNING KEY) <gnodet@gmail.com>"

This is a different PGP key than that listed for ASF ID "gnodet" at https://people.apache.org/keys/committer/gnodet

Guillaume is a member of many Apache projects, but it is unclear which project "org.apache.sshd" is part of:
https://people.apache.org/committer-index.html#gnodet

---
This builds on PR #614 and resolves its build error.