### PR TITLE
Additional key for com.google.protobuf:protobuf-java

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>[3.19.4]</version>
+            <version>[3.20.0]</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.maven-scm-provider-svnjava</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -170,6 +170,7 @@ com.google.googlejavaformat     = \
                                   0xEE0CA873074092F806F59B65D364ABAA39A47320
 
 com.google.protobuf:protobuf-java = \
+                                  0x187366A3FFE6BF8F94B9136A9987B20C8F6A3064, \
                                   0x3D11126EA77E4E07FBABB38614A84C976D265B25, \
                                   0x696B6199A2A9D8C29CE78CC0D041CAD2E452550F, \
                                   0xE7D86375B2E8A347EBCA8DA9C2E8DCFEA41DA422, \


### PR DESCRIPTION
Signature resolves to "mkruskal <mkruskal@google.com>"

GitHub user "mkruskal-google" has recently published the next pre-release of protobuf-java:
https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.1-rc1
https://github.com/mkruskal-google

The GitHub commits are not signed, however, so unable to find any specific PGP keys for comparison.

This builds on PR #626 and resolves its build error.