### PR TITLE
new keys for dependencies of checkstyle-10.1

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -144,6 +144,11 @@
             <type>pom</type>
         </dependency>
         <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>[10.1]</version>
+        </dependency>
+        <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
             <version>[5.14.2]</version>
@@ -228,6 +233,11 @@
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
             <version>[3.5.0]</version>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>[4.6.3]</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -850,6 +860,11 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>[1.18.22]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>[0.10.2]</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -298,7 +298,9 @@ eu.medsea.mimeutil:mime-util    = noSig
 
 geronimo-spec                   = noSig
 
-info.picocli                    = 0x8756C4F765C9AC3CB6B85D62379CE192D401AB61
+info.picocli                    = \
+                                  0x8756C4F765C9AC3CB6B85D62379CE192D401AB61, \
+                                  0xAA417737BD805456DB3CBDDE6601E5C08DCCBB96
 
 informa:informa                 = noSig
 
@@ -992,6 +994,8 @@ org.ow2.asm:*:[6.0,7.2)         = noSig
 org.ow2.asm                     = 0xA5BD02B93E7A40482EB1D66A5F69AD087600B22C
 
 org.reactivestreams             = 0xA5B2DDE7843E7CA3E8CAABD02383163BC40844FD
+
+org.reflections:reflections     = 0x3F2A008A91D11A7FAC4A0786F13D3E721D56BD54
 
 org.rnorth.duct-tape:duct-tape  = 0x8756C4F765C9AC3CB6B85D62379CE192D401AB61
 


### PR DESCRIPTION
info.picocli
---
Signature resolves to "Popma Remko <remkop@yahoo.com>"

GitHub user "remkop" owns the repository related to this project:
https://github.com/remkop/picocli/releases/tag/v4.6.3

org.reflections:reflections
---
Signature does not have any user ID:
`gpg: key F13D3E721D56BD54: new key but contains no user ID - skipped`

The release dates match between GitHub and Maven Central, which at least means it is likely the same person with access to both GitHub and Maven Central.
https://github.com/ronmamo/reflections/releases/tag/0.10.2
https://repo1.maven.org/maven2/org/reflections/reflections/0.10.2/

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
