### PR TITLE
Additional key for com.google.errorprone:error_prone_annotations

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
-            <version>[2.12.1]</version>
+            <version>[2.13.1]</version>
         </dependency>
         <dependency>
             <groupId>com.google.googlejavaformat</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -154,7 +154,8 @@ com.googlecode.javaewah        = 0x015479E1055341431B4545AB72475FD306B9CAB7
 
 com.google.errorprone:error_prone_annotations = \
                                   0x5CE325996A35213326AE2C68912D2C0ECCDA55C0, \
-                                  0x6F656B7F6BFB238D38ACF81F3C27D97B0C83A85C
+                                  0x6F656B7F6BFB238D38ACF81F3C27D97B0C83A85C, \
+                                  0xEE0CA873074092F806F59B65D364ABAA39A47320
 com.google.errorprone           = \
                                   0x56053CEDBA17E065DE7FB97BEBA8E97B15086E24, \
                                   0x7615AD56144DF2376F49D98B1669C4BB543E0445, \


### PR DESCRIPTION
Signature resolves to "Liam Miller-Cushon (Error Prone releases) <cushon@google.com>".

This key is also already in the map for groupId "com.google.googlejavaformat".

This builds on PR #651 and resolves its build error.