### PR TITLE
Additional key for org.apache.xbean

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -675,7 +675,7 @@
         <dependency>
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-reflect</artifactId>
-            <version>[4.20]</version>
+            <version>[4.21]</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -702,6 +702,7 @@ org.apache.ws.xmlschema         = \
                                   0xDB45ECD19B97514F727105AE67BF80B10AD53983
 
 org.apache.xbean                = \
+                                  0x1AA8CF92D409A73393D0B736BFF2EE42C8282E76, \
                                   0x223D3A74B068ECA354DC385CE126833F9CF64915, \
                                   0x82D8419BA697F0E7FB85916EE91287822FDB81B1, \
                                   0xEA23DB1360D9029481E7F2EFECDFEA3CB4493B94


### PR DESCRIPTION
Signature resolves to "Jean-Baptiste Onofré <jbonofre@apache.org>".

Listed as ASF ID "jbonofre", but no PGP keys given:
https://people.apache.org/committer-index.html

GitHub user "jbonofre" authored the associated release:
https://github.com/apache/geronimo-xbean/releases/tag/xbean-4.21
https://github.com/jbonofre

This builds on PR #654 and resolves its build error.