### PR TITLE
httpcomponents 5 is released under multiple groupId

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -588,6 +588,16 @@
             <version>[4.4.15]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>[5.1.3]</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>[5.1.3]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mime4j-core</artifactId>
             <version>[0.8.7]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -593,7 +593,7 @@ org.apache.geronimo.specs       = \
 
 org.apache.groovy               = 0x34441E504A937F43EB0DAEF96A65176A0FB1CD0B
 
-org.apache.httpcomponents       = \
+org.apache.httpcomponents.*     = \
                                   0x0785B3EFF60B1B1BEA94E0BB7C25280EAE63EBE5, \
                                   0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB
 


### PR DESCRIPTION
Changed keys map entry to use asterisk wildcard.

Added tests for httpclient5 and httpcore5.

No new PGP keys.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
