### PR TITLE
new key for guru.nidi.*

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -240,6 +240,21 @@
             <version>[3.5.0]</version>
         </dependency>
         <dependency>
+            <groupId>guru.nidi</groupId>
+            <artifactId>graphviz-java</artifactId>
+            <version>[0.18.1]</version>
+        </dependency>
+        <dependency>
+            <groupId>guru.nidi.com.eclipsesource.j2v8</groupId>
+            <artifactId>j2v8_linux_x86_64</artifactId>
+            <version>[4.6.0]</version>
+        </dependency>
+        <dependency>
+            <groupId>guru.nidi.com.kitfox</groupId>
+            <artifactId>svgSalamander</artifactId>
+            <version>[1.1.3]</version>
+        </dependency>
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>[4.6.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -302,6 +302,8 @@ eu.medsea.mimeutil:mime-util    = noSig
 
 geronimo-spec                   = noSig
 
+guru.nidi.*                     = 0x7285B9747FA1B77E008CD9CAC78DCFD987057597
+
 info.picocli                    = \
                                   0x8756C4F765C9AC3CB6B85D62379CE192D401AB61, \
                                   0xAA417737BD805456DB3CBDDE6601E5C08DCCBB96


### PR DESCRIPTION
Signature resolves to "Stefan Niederhauser <ich@nidi.guru>".

Related GitHub user "nidi3" published the associated GitHub release:
https://github.com/nidi3/graphviz-java/releases/tag/graphviz-java-parent-0.18.1
https://github.com/nidi3

PR #677 should go in before this one.