### PR TITLE
new key for net.arnx

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -466,6 +466,11 @@
             <version>[8.0.28]</version>
         </dependency>
         <dependency>
+            <groupId>net.arnx</groupId>
+            <artifactId>nashorn-promise</artifactId>
+            <version>[0.1.3]</version>
+        </dependency>
+        <dependency>
             <groupId>net.i2p.crypto</groupId>
             <artifactId>eddsa</artifactId>
             <version>[0.3.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -458,6 +458,8 @@ mysql:mysql-connector-java:[8.0.28,) = 0x859BE8D7C586F538430B19C2467B942D3A79BD2
 
 nekohtml                        = noSig
 
+net.arnx                        = 0xEA1CC8EB96ACB305D55872774330D21C2BC8B5E3
+
 net.bytebuddy                   = \
                                   0xB4AC8CDC141AF0AE468D16921DA784CCB5C46DD5, \
                                   0xF42B96B8648B5C4A1C43A62FBB2914C1FA0811C3


### PR DESCRIPTION
Signature resolves to "Hidekatsu Izuno <hidekatsu.izuno@gmail.com>".

The related GitHub user "hidekatsu-izuno" published the associated GitHub release:
https://github.com/hidekatsu-izuno/nashorn-promise/releases/tag/v0.1.3
https://github.com/hidekatsu-izuno

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
