### PR TITLE
new key for io.github.classgraph

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -250,6 +250,11 @@
             <version>[2.0.29]</version>
         </dependency>
         <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>[4.8.146]</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
             <version>[4.1.76.Final]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -310,6 +310,8 @@ informa:informa                 = noSig
 
 io.dropwizard.*                 = 0xEDA86E9FB607B5FC9223FB767D4868B53E31E7AD
 
+io.github.classgraph            = 0x1F47744C9B6E14F2049C2857F1F111AF65925306
+
 io.github.resilience4j          = \
                                   0x8756C4F765C9AC3CB6B85D62379CE192D401AB61, \
                                   0x94FAC9D5B165E80F1F2D9A103FFA7DB1EC0FF1A2


### PR DESCRIPTION
Signature resolves to "Luke Hutchison <luke.hutch@gmail.com>".

The related GitHub user "lukehutch" published the associated GitHub release:
https://github.com/classgraph/classgraph/releases/tag/classgraph-4.8.146
https://github.com/lukehutch

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
