### PR TITLE
new keys for io.netty

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -245,6 +245,16 @@
             <version>[2.0.29]</version>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>[4.1.76.Final]</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>[4.1.76.Final]</version>
+        </dependency>
+        <dependency>
             <groupId>io.reformanda.semper</groupId>
             <artifactId>dependencyversion-maven-plugin-parent</artifactId>
             <version>[1.0.1]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -314,6 +314,11 @@ io.github.resilience4j          = \
 
 io.leangen.geantyref            = 0x41B962CF9AA2A26FF1F234D2A6144824624A3CBA
 
+io.netty                        = \
+                                  0x0D35D3F60078655126908E8AF3D1600878E85A3D, \
+                                  0x176E27B72061F21D6FE6286241CB03A1BB3BAD60, \
+                                  0x7E22D50A7EBD9D2CD269B2D4056ACA74D46000BF
+
 io.reactivex.rxjava2            = 0x1D9AA7F9E1E2824728B8CD1794B291AEF984A085
 
 io.reformanda.semper            = 0x12019C612F8760FCE59238B55812C79D00186A37


### PR DESCRIPTION
First signature resolves to "Netty Project Bot <netty-project-bot@users.noreply.github.com>".

This is the GitHub user that published the associated release:
https://github.com/netty/netty/releases/tag/netty-4.1.76.Final
https://github.com/netty-project-bot

---

Second signature resolves to "Chris Vest (chrisvest on github, chvest on twitter) <mr.chrisvest@gmail.com>".

GitHub user "chrisvest" is a frequent committer on the project:
https://github.com/netty/netty/commits/4.1
https://github.com/chrisvest

---

Third signature resolves to "Norman Maurer <norman@apache.org>".

GitHub user "normanmaurer" is a frequent committer on the project:
https://github.com/netty/netty/commits/4.1
https://github.com/normanmaurer

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
