### PR TITLE
new key for io.rsocket

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -306,6 +306,11 @@
             <version>[1.0.1]</version>
         </dependency>
         <dependency>
+            <groupId>io.rsocket</groupId>
+            <artifactId>rsocket-core</artifactId>
+            <version>[1.1.2]</version>
+        </dependency>
+        <dependency>
             <groupId>io.vavr</groupId>
             <artifactId>vavr</artifactId>
             <version>[0.10.4]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -333,6 +333,8 @@ io.reactivex.rxjava2            = 0x1D9AA7F9E1E2824728B8CD1794B291AEF984A085
 
 io.reformanda.semper            = 0x12019C612F8760FCE59238B55812C79D00186A37
 
+io.rsocket                      = 0x9B32CBC0F3F6BA4C13D611FC21871D2A9AB66A31
+
 io.vavr                         = \
                                   0x1D339B6A68AE2E8DAEDA65D5276962CA56E73C81, \
                                   0x2E732921F44FD0DB434DB5CC55A58E21609DEC6E


### PR DESCRIPTION
Signature resolves to "RSocket Admin <admin@rsocket.io>".

Unable to find any way to specifically validate this PGP key, however.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
