### PR TITLE
new key for org.abego.treelayout

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -498,6 +498,11 @@
             <version>[3.3.2]</version>
         </dependency>
         <dependency>
+            <groupId>org.abego.treelayout</groupId>
+            <artifactId>org.abego.treelayout.core</artifactId>
+            <version>[1.0.3]</version>
+        </dependency>
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
             <version>[3.5.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -508,6 +508,8 @@ ognl:ognl:3.0                   = 0xA019F1D2A4C89ED86531141EF5587322DD8B8819
 ognl:ognl:3.1.12                = 0xE157EEB8D208EEB23F5723AC06F21382801CEF5F
 ognl:ognl:[3.0.1,)              = 0x0E008698344E62B90633B7C62841610663AFBB1F
 
+org.abego.treelayout            = 0xD790F72EA8FD39551012B62DCF9F3090CE4CB752
+
 org.antlr:antlr:(,3.4-beta4]                  = noSig
 org.antlr:antlr-master:(,3.4-beta4]           = noSig
 org.antlr:antlr-runtime:(,3.4-beta4]          = noSig


### PR DESCRIPTION
Signature resolves to "abego Software GmbH, Germany (Key for Maven) <contact@abego.org>".

The related GitHub user "abego" published the associated GitHub release:
https://github.com/abego/treelayout/releases/tag/v1.0.3
https://github.com/abego

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
