### PR TITLE
new key for org.glassfish:javax.json

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -800,6 +800,11 @@
             <version>[2.3.31]</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>[1.1.4]</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>jakarta.servlet.jsp.jstl</artifactId>
             <version>[2.0.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -869,6 +869,10 @@ org.fusesource.hawtbuf          = 0xE5B8247AF8A619A28F90FDFC9FF25980F5BA7E4F
 
 org.glassfish                   = 0x7AA34304FF173025AA394C7C2C026998703FFA67
 
+org.glassfish:javax.json        = \
+                                  0x4F7E32D440EF90A83011A8FC6425559C47CC79C4, \
+                                  0x70CD19BFD9F6C330027D6F260315BFB7970A144F
+
 org.glassfish.external          = 0x98B8EC91D603095B68BB257D5E06B3EFC614EB37
 
 org.glassfish.gmbal             = 0x98B8EC91D603095B68BB257D5E06B3EFC614EB37


### PR DESCRIPTION
First signature resolves to "java_re <GF_RELEASE_WW@oracle.com>".

Second signature resolves to "EE4J Automated Build <tomas.kraus@oracle.com>".

Both keys are already in the map for several Java EE-related artifacts.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
