### PR TITLE
new key for org.hdrhistogram

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -835,6 +835,11 @@
             <version>[2.0.0]</version>
         </dependency>
         <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>[2.1.12]</version>
+        </dependency>
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-jodatime2</artifactId>
             <version>[3.28.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -911,6 +911,8 @@ org.hamcrest                    = \
                                   0x4DB1A49729B053CAF015CEE9A6ADFC93EF34893E, \
                                   0xE3A9F95079E84CE201F7CF60BEDE11EAF1164480
 
+org.hdrhistogram                = 0xE113159331A1F87BFC2A93D0960D2E8635A91268
+
 org.hibernate.*                 = noSig
 
 org.iq80.snappy                 = 0x9E93DB1192CEE3D3B581AABB37E9D58EA4598641


### PR DESCRIPTION
Signature resolves to "Gil Tene <gil@azul.com>".

The related GitHub user "giltene" published the associated GitHub release:
https://github.com/HdrHistogram/HdrHistogram/releases/tag/HdrHistogram-2.1.12
https://github.com/giltene

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
