### PR TITLE
new key for org.latencyutils

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -920,6 +920,11 @@
             <version>[1.7.0]</version>
         </dependency>
         <dependency>
+            <groupId>org.latencyutils</groupId>
+            <artifactId>LatencyUtils</artifactId>
+            <version>[2.0.3]</version>
+        </dependency>
+        <dependency>
             <groupId>org.libreoffice</groupId>
             <artifactId>libreoffice</artifactId>
             <version>[7.3.3]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -982,6 +982,8 @@ org.jvnet.staxex                = 0x06A4D15D9FA796BA5DECF592CE8B1D1D2530EDC5, \
 
 org.kopitubruk.util             = 0xBED8150B4DF16120DEAFD461D90AF6F50CA9ADC1
 
+org.latencyutils                = 0x7A1D848E7C2AF85EEBA69C99E7BF252CF360097E
+
 org.libreoffice                 = \
                                   0x1C67D33B45FF883CF72675872B72BCDB418E6BC6, \
                                   0xC2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3


### PR DESCRIPTION
Signature resolves to "Gil Tene <gil@cloud7.com>".

The related GitHub user "giltene" published the associated GitHub release:
https://github.com/LatencyUtils/LatencyUtils/releases/tag/LatencyUtils-2.0.3
https://github.com/giltene