### PR TITLE
new key for org.rocksdb

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -917,6 +917,11 @@
             <version>[0.10.2]</version>
         </dependency>
         <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>[7.1.2]</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>[1.7.36]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -1024,6 +1024,8 @@ org.reflections:reflections     = 0x3F2A008A91D11A7FAC4A0786F13D3E721D56BD54
 
 org.rnorth.duct-tape:duct-tape  = 0x8756C4F765C9AC3CB6B85D62379CE192D401AB61
 
+org.rocksdb                     = 0xD4A08A8AB731BF576354A8183EF2B4866A540119
+
 org.simplify4u.*                = \
                                   0x57EB3F12030A57BAA31CAAD5BE3E2A5CB80794EE, \
                                   0x6636274B2E8BEA9D15A61143F8484389379ACEAC


### PR DESCRIPTION
Signature resolves to "Release Team <release@evolvedbinary.com>".

The GitHub user "hx235" created the associated GitHub release:
https://github.com/facebook/rocksdb/releases/tag/v7.1.2
https://github.com/hx235

I am unable to specifically connect this PGP to the GitHub identity or release.  However, it is worth noting the GitHub release and Maven Central artifacts have a matching date of 2022-04-20.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
