### PR TITLE
new key for org.openrewrite.*

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -980,6 +980,11 @@
             <version>[1.7.14]</version>
         </dependency>
         <dependency>
+            <groupId>org.openrewrite.maven</groupId>
+            <artifactId>rewrite-maven-plugin</artifactId>
+            <version>[4.22.2]</version>
+        </dependency>
+        <dependency>
             <groupId>org.ostermiller</groupId>
             <artifactId>utils</artifactId>
             <!-- Cannot use "[1.07.00]" due to missing maven-metadata.xml at

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -1037,6 +1037,8 @@ org.postgresql:postgresql       = 0x3750777B9C4B7D233B9D0C40307A96FBA0292109
 
 org.projectlombok                = 0xD421D1DF4570BFB13E485D0BF95ADD0A28D2F139
 
+org.openrewrite.*                = 0xF36CA0C4B500F0CDDE0C5AA1913F763CD0F9CFD8
+
 org.ow2.asm:*:[6.0,7.2)         = noSig
 org.ow2.asm                     = 0xA5BD02B93E7A40482EB1D66A5F69AD087600B22C
 


### PR DESCRIPTION
Signature resolves to "Aaron Gershman (Aaron Gershman at ModerneInc) <aaron@moderne.io>".

GitHub user "tkvangorder" created the associated GitHub release:
https://github.com/openrewrite/rewrite-maven-plugin/releases/tag/v4.22.2
https://github.com/tkvangorder

I am unable to specifically connect this PGP to the GitHub identity or release.  However, it is worth noting the GitHub release and Maven Central artifacts have a matching date of 2022-04-07.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
