### PR TITLE
Additional key for biz.aQute.bnd

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -41,6 +41,11 @@
             <version>[1.0b5]</version>
         </dependency>
         <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>[6.2.0]</version>
+        </dependency>
+        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>[1.5.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -29,7 +29,9 @@ avalon-framework                = noSig
 backport-util-concurrent        = noSig
 
 biz.aQute:bndlib:0.0.145        = noSig
-biz.aQute.bnd                   = 0x32D98FFD50617F6ED7E6ABD236FEECF06C2DA10B
+biz.aQute.bnd                   = \
+                                  0x32D98FFD50617F6ED7E6ABD236FEECF06C2DA10B, \
+                                  0xF4FD8D1EA4A590D774A6BA777B534D9959CF9EAC
 
 bsh                             = noSig
 


### PR DESCRIPTION
Signature resolves to "BJ Hargrave (Open Source Development) <bj@hargrave.dev>".

GitHub user "bjhargrave" created the associated GitHub release:
https://github.com/bndtools/bnd/releases/tag/6.2.0
https://github.com/bjhargrave

This PGP key is the same used for verified commits on the GitHub release tag.