### PR TITLE
Additional key for org.osgi

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -985,6 +985,11 @@
             <version>[4.22.2]</version>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+            <version>[8.1.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.ostermiller</groupId>
             <artifactId>utils</artifactId>
             <!-- Cannot use "[1.07.00]" due to missing maven-metadata.xml at

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -1025,7 +1025,9 @@ org.opentest4j                  = 0xFF6E2C001948C5F2F38B0CC385911F425EC61B51
 
 org.osgi:org.osgi.compendium    = noSig
 
-org.osgi                        = 0x1AF010D408C1852AB6EFD4B651CDB4A9DAAC1CBC
+org.osgi                        = \
+                                  0x1AF010D408C1852AB6EFD4B651CDB4A9DAAC1CBC, \
+                                  0xEAFC1F3B2FCED6AFD046C7D5734AEF3D43509290
 
 org.ostermiller:utils           = noSig
 


### PR DESCRIPTION
Signature resolves to "BJ Hargrave (bintray.com osgi organization) <hargrave@us.ibm.com>".

GitHub user "bjhargrave" created the associated GitHub release:
https://github.com/osgi/osgi/releases/tag/8.0.0.1
https://github.com/bjhargrave

This PGP key is the same used for verified commits on the GitHub release tag.