### PR TITLE
new key for org.hibernate.validator

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -900,6 +900,11 @@
             <version>[2.1.12]</version>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>[8.0.0.Alpha3]</version>
+        </dependency>
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-jodatime2</artifactId>
             <version>[3.28.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -928,6 +928,7 @@ org.hamcrest                    = \
 org.hdrhistogram                = 0xE113159331A1F87BFC2A93D0960D2E8635A91268
 
 org.hibernate.*                 = noSig
+org.hibernate.validator         = 0x894F14D98D7F20D5E82645E3DFE102108BF9381F
 
 org.iq80.snappy                 = 0x9E93DB1192CEE3D3B581AABB37E9D58EA4598641
 


### PR DESCRIPTION
The PGP key does not have any user ID:
`gpg: key DFE102108BF9381F: new key but contains no user ID - skipped`

It is worth noting that this same PGP key has been used for all of the recent releases.

The GitHub user "Hibernate-CI" published the associated release:
https://github.com/hibernate/hibernate-validator/releases/tag/8.0.0.Alpha3
https://github.com/Hibernate-CI