### PR TITLE
New key used on protobuf-java-3.21.2

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>[3.21.1]</version>
+            <version>[3.21.2]</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.maven-scm-provider-svnjava</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -176,6 +176,7 @@ com.google.protobuf:protobuf-java = \
                                   0x187366A3FFE6BF8F94B9136A9987B20C8F6A3064, \
                                   0x2E5B73C6EFD2EB453104C2EAE6EC76B4C6D3AE8E, \
                                   0x3D11126EA77E4E07FBABB38614A84C976D265B25, \
+                                  0x51608DEA69F297BEA56ADF9BAEAA0761DF8CA3A1, \
                                   0x696B6199A2A9D8C29CE78CC0D041CAD2E452550F, \
                                   0xDF93A4EDFE686D687CC4B9FCB55F59562D5321EF, \
                                   0xE7D86375B2E8A347EBCA8DA9C2E8DCFEA41DA422, \


### PR DESCRIPTION
Signature resolves to "theodore rose <theodorerose@google.com>".

This extends and resolves the build error in PR #829