### PR TITLE
new key for org.eclipse.angus

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -859,6 +859,11 @@
             <version>[4.4.1]</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-activation</artifactId>
+            <version>[1.0.0]</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>ecj</artifactId>
             <version>[3.30.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -857,6 +857,8 @@ org.eclipse.aether              = \
                                   0xBA926F64CA647B6D853A38672E2010F8A7FF4A41, \
                                   0xFB11D4BB7B244678337AAD8BC7BF26D0BB617866
 
+org.eclipse.angus               = 0x284E7978CDDCEC682D4C6C435CDC001823AE5BEB
+
 org.eclipse.core:resources:3.3.0-v20070604 = noSig
 
 org.eclipse.jdt:ecj             = 0x462E0F0FD51D11AB1FF74EC77AA1F762B414F87E


### PR DESCRIPTION
Signature resolves to "Eclipse Angus Project <angus-dev@eclipse.org>".

This appears to be a new project at https://github.com/eclipse-ee4j/angus-activation

This adds the missing dependency for PR #785 and #824