### PR TITLE
Additional key for org.eclipse.jetty.websocket

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -876,7 +876,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-parent</artifactId>
-            <version>[11.0.9]</version>
+            <version>[11.0.11]</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -880,7 +880,8 @@ org.eclipse.jetty.toolchain.setuid \
 
 org.eclipse.jetty.websocket     = \
                                   0x5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4, \
-                                  0x8B096546B1A8F02656B15D3B1677D141BCF3584D
+                                  0x8B096546B1A8F02656B15D3B1677D141BCF3584D, \
+                                  0xB59B67FD7904984367F931800818D9D68FB67BAC
 
 # version (,0.0.0],[0.0.0,) is workaround for https://github.com/s4u/pgpverify-maven-plugin/issues/135
 org.eclipse.sisu:*:(,0.0.0],[0.0.0,) = 0xCF17E92C9FFA55316B5DB83901D734EE5EE9C3F8


### PR DESCRIPTION
Signature resolves to "Joakim Erdfelt <joakime@apache.org>".

Signature matches ASF ID "joakime" published at https://people.apache.org/keys/committer/joakime

Unable to specifically associate the Apache ID with this Jetty project, but we are assured the artifact was published by an Apache member.

This extends and resolves the build error of PR #825