### PR TITLE
new key for com.paypal.sdk

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -148,6 +148,11 @@
             <version>[5.6]</version>
         </dependency>
         <dependency>
+            <groupId>com.paypal.sdk</groupId>
+            <artifactId>rest-api-sdk</artifactId>
+            <version>[1.14.0]</version>
+        </dependency>
+        <dependency>
             <groupId>com.pragmatickm</groupId>
             <artifactId>pragmatickm-parent</artifactId>
             <version>[1.13.2]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -220,6 +220,8 @@ com.newmediaworks               = 0x940C50A840DF4E9BC77FF3E587B44025897B20B0
 
 com.opencsv                     = 0xAB1DC33940689C44669107094989E0E939C2999B
 
+com.paypal.sdk                  = 0xF757E7E141E0844E351734EDE9F2C86A0DE39B39
+
 com.pholser                     = \
                                   0x517B94F8D0A46317A28D8AB30DA8A5EC02D11EAD, \
                                   0x92F6B50F73DF09039114B367DED1E9914638F44D


### PR DESCRIPTION
Signature resolves to "PayPal <DL-PP-Platform-Java-SDK@paypal.com>".

It is worth noting this project is deprecated per https://github.com/paypal/PayPal-Java-SDK
We do not anticipate any future releases of the project.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
