### PR TITLE
Additional key for org.eclipse.jetty.websocket

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -896,7 +896,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-parent</artifactId>
-            <version>[11.0.11]</version>
+            <version>[11.0.12]</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -902,7 +902,8 @@ org.eclipse.jetty.toolchain.setuid \
 org.eclipse.jetty.websocket     = \
                                   0x5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4, \
                                   0x8B096546B1A8F02656B15D3B1677D141BCF3584D, \
-                                  0xB59B67FD7904984367F931800818D9D68FB67BAC
+                                  0xB59B67FD7904984367F931800818D9D68FB67BAC, \
+                                  0xF254B35617DC255D9344BCFA873A8E86B4372146
 
 # version (,0.0.0],[0.0.0,) is workaround for https://github.com/s4u/pgpverify-maven-plugin/issues/135
 org.eclipse.sisu:*:(,0.0.0],[0.0.0,) = 0xCF17E92C9FFA55316B5DB83901D734EE5EE9C3F8


### PR DESCRIPTION
Signature resolves to "Olivier Lamy <olamy@apache.org>".
 
This key is already in the map for numerous other projects.

This extends and resolves the build error of PR #1029