### PR TITLE
new keys for cglib:cglib

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -46,6 +46,11 @@
             <version>[6.3.1]</version>
         </dependency>
         <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib</artifactId>
+            <version>[3.3.0]</version>
+        </dependency>
+        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>[1.5.0]</version>
@@ -503,11 +508,6 @@
             <artifactId>informa</artifactId>
             <version>[0.6.0]</version>
             <exclusions>
-                <!-- cglib:cglib is not yet in pgp-keys-map -->
-                <exclusion>
-                    <groupId>cglib</groupId>
-                    <artifactId>cglib</artifactId>
-                </exclusion>
                 <!-- ehcache:ehcache is not yet in pgp-keys-map -->
                 <exclusion>
                     <groupId>ehcache</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -35,6 +35,11 @@ biz.aQute.bnd                   = \
 
 bsh                             = noSig
 
+cglib:cglib:(,2.2]              = noSig
+cglib:cglib:2.2_beta1           = 0x69859CF50A3C1EB40A90D5FD2D6641C6AF88103E
+cglib:cglib:[2.2.2,3.1]         = 0xE78AA45938D10249E08CC1C752E6585E0102B84D
+cglib:cglib:[3.2.0,)            = 0x07DBC3C1AB1F4468471656061C8D5EF0DF2B70D4
+
 ch.qos.logback                  = 0x475F3B8E59E6E63AA78067482C7B12F2A511E325
 
 ch.ethz.ganymed                = noSig


### PR DESCRIPTION
The oldest artifacts are unsigned.

The oldest signature resolves to "Maven Central Java.net import".  This key is already in the map for several other projects.

The next oldest artifacts are signed by "Stuart McCulloch (Sonatype) <mcculls@sonatype.com>".  This key is also already in the map for "org.sonatype.*"

The newest artfacts are signed by "Sam Berlin <sberlin@gmail.com>".  It is worth noting this matches the GitHub user of the recent releases:
https://github.com/cglib/cglib/releases/tag/RELEASE_3_3_0
https://github.com/sameb

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
