### PR TITLE
new key for com.github.cliftonlabs:json-simple

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -83,6 +83,11 @@
             <version>[3.1.1]</version>
         </dependency>
         <dependency>
+            <groupId>com.github.cliftonlabs</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>[4.0.1]</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-api</artifactId>
             <version>[3.2.13]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -116,6 +116,13 @@ com.aoindustries                = 0x3FF945C37048D113E997AEC7CE70AA9A5BD10E01
 
 com.github.ben-manes.caffeine   = 0x635EE627345F3C1DD422B2E207D3516820BCF6B1
 
+com.github.cliftonlabs:json-simple:(,2.1.2] \
+                                = 0xE543A38B156A6200EA0A0D4E3AAEECBE57E27E2E
+com.github.cliftonlabs:json-simple:[2.2.0,3.1.0] \
+                                = 0xD4173520C54781C310C6E10C4425263EB7F112F0
+com.github.cliftonlabs:json-simple:[3.1.1,) \
+                                = 0xA5A6CA64706880C873677EEF1E831E5567C07466
+
 com.github.docker-java          = 0x08B09F787B6745E796CE6DBE100306F2B3793BF3
 
 com.beust                       = \


### PR DESCRIPTION
Oldest artifacts are signed by "Clifton Labs (maintainer) <davin.loegering@cliftonlabs.com>".

The signing key then changed to "Clifton Labs (Maven Maintainer) <davin.loegering@cliftonlabs.com>".

Finally, the most recent releases are signed by "Clifton Labs <davin.loegering@cliftonlabs.com>".

It is worth noting the project's GitHub: https://github.com/cliftonlabs/json-simple

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
