### PR TITLE
Wildcard groupId for org.apache.velocity.*

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -788,6 +788,11 @@
             <version>[1.0M10]</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.velocity.tools</groupId>
+            <artifactId>velocity-tools-generic</artifactId>
+            <version>[3.1]</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
             <version>[1.4.0]</version>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -746,7 +746,8 @@ org.apache.tomcat.*             = \
 org.apache.tomcat.maven         = 0xF254B35617DC255D9344BCFA873A8E86B4372146
 
 org.apache.velocity:velocity:1.5 = noSig
-org.apache.velocity             = \
+org.apache.velocity.tools:velocity-tools:2.0-alpha1 = noSig
+org.apache.velocity.*           = \
                                   0x7B9751FC3F01F134F476464CD0EB627D4885CED1, \
                                   0xCE4439C1BEF3DA83B1832F9DBEFEEF227A98B809
 


### PR DESCRIPTION
There are artifacts in the groupId org.apache.velocity.tools signed by the same keys.

<!-- Good practices for PR -->
<!--      one PR - one commit - so please squash all if required -->
<!--      one PR - one feature - so if changes are independent please create many PR -->
<!--      after review with change request please answer in 14 days -->
