### PR TITLE
 org.codehaus.gpars:gpars:pom/jar:1.2.1 = noSig/noKey

### DIFF
--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -810,6 +810,9 @@ org.codehaus.gmaven.*           = \
                                   0x045B3D6AE9500CE0F930DFE48D948CAF35543C27, \
                                   0x0DCF749D41A80E58041AAE1728F57F70167C0B3A
 
+org.codehaus.gpars:gpars:pom:1.2.1 = noSig
+org.codehaus.gpars:gpars:jar:1.2.1 = noKey
+
 org.codehaus.groovy:groovy:(,2.2.1] = noSig
 org.codehaus.groovy:groovy-all:(,2.2.1] = noSig
 org.codehaus.groovy             = \


### PR DESCRIPTION
- https://github.com/GPars/GPars/issues/62