### PR TITLE
mysql:mysql-connector-java relocated to com.mysql:mysql-connector-j

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -158,6 +158,11 @@
             <version>[4.1.0]</version>
         </dependency>
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>[8.0.31]</version>
+        </dependency>
+        <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>[5.7.1]</version>
@@ -563,7 +568,15 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <!--
+            Version 8.0.31, which is intended to be a relocation to com.mysql:mysql-connector-j,
+            is malformed and failing to perform the intended relocation. The pom was erroneously
+            uploaded as "mysql-connector-j-8.0.31.pom" instead of "mysql-connector-java-8.0.31.pom".
+            Staying on version 8.0.30 until this issue is resolved.
+            -->
             <version>[8.0.30]</version>
+            <!-- pom-only since the final release is expected to be a relocation to com.mysql:mysql-connector-j -->
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>net.arnx</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -233,6 +233,8 @@ com.mattbertolini               = 0x0D23D5975075143A9DE198953165E1E333C131A5
 
 com.mks.api                     = 0xF5FE3E099957FCC561BE34C2D9EB0830E9BFA161
 
+com.mysql:mysql-connector-j:[8.0.31,) = 0xF046369B06B761AC86D9849F71B329993BFFCFDD
+
 com.newmediaworks               = 0x940C50A840DF4E9BC77FF3E587B44025897B20B0
 
 com.opencsv                     = 0xAB1DC33940689C44669107094989E0E939C2999B
@@ -506,7 +508,7 @@ log4j                           = 0x9D23533896A9784703585B6286E02C5A42196CA8
 logkit                          = noSig
 
 mysql:mysql-connector-java:(,8.0.27] = 0xA4A9406876FCBD3C456770C88C718D3B5072E1F5
-mysql:mysql-connector-java:[8.0.28,) = 0x859BE8D7C586F538430B19C2467B942D3A79BD29
+mysql:mysql-connector-java:[8.0.28,8.0.30] = 0x859BE8D7C586F538430B19C2467B942D3A79BD29
 
 nekohtml                        = noSig
 


### PR DESCRIPTION
New signature resolves to "Oracle Maven Release Key 2 <secalert_us@oracle.com>".

This does not match any documented MySQL signing key at https://dev.mysql.com/doc/refman/8.0/en/verifying-package-integrity.html