### PR TITLE
Declare jboss-logging to be not signed

### DIFF
--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -1337,6 +1337,11 @@
             <artifactId>expressly</artifactId>
             <version>[5.0.0]</version>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>[3.4.3.Final]</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -1021,6 +1021,8 @@ org.jacoco                      = 0xA413F67D71BEEC23ADD0CE0ACB43338E060CF9FA
 
 org.jboss:jandex                = noSig
 
+org.jboss.logging:jboss-logging = noSig
+
 org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.1.1.Final = noSig
 
 org.jfree:jfreechart            = 0x1A6782E4EBF49045C8040D1B93157E22A3A5461C


### PR DESCRIPTION
- https://github.com/s4u/pgp-keys-map/pull/1742
- https://github.com/s4u/pgp-keys-map/pull/1743

-----

This is very strange case. I supposed that `jboss-logging` used in my project was very old and was missing signature due to that. But even the latest https://repo.maven.apache.org/maven2/org/jboss/logging/jboss-logging/3.5.3.Final/ (2023-07-06 00:34) are unsigned. 

https://central.sonatype.org/publish/requirements/#sign-files-with-gpgpgp
> *Sign Files with GPG/PGP*
> All files deployed need to be signed with GPG/PGP and a .asc file containing the signature must be included for each file. E.g. if you deploy the files

Apparently **must be included** can be relaxed for select ones...