### PR TITLE
New key for org.apache.maven

### DIFF
--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -745,6 +745,7 @@ org.apache.maven.*              = \
                                   0x82C9EC0E52C47A936A849E0113D979595E6D01E1, \
                                   0x84789D24DF77A32433CE1F079EB80E92EB2135B1, \
                                   0x849FB4F1AF3D17CDE4DE5E710704ADDF1D821345, \
+                                  0x88BE34F94BDB2B5357044E2E3A387D43964143E3, \
                                   0x998AF0E2B935996F5CEBD56B9B1FDA9F3C062231, \
                                   0x9FFED7A118D45A44E4A1E47130E6F80434A72A7F, \
                                   0xAE9E53FC28FF2AB1012273D0BF1518E0160788A2, \


### PR DESCRIPTION
New key is present in https://downloads.apache.org/maven/KEYS.