### PR TITLE
Add keys used to sign the recent (incl. 2.4.0) modello releases

### DIFF
--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -881,6 +881,9 @@ org.codehaus.jackson = noSig
 
 org.codehaus.jsr166-mirror      = noSig
 
+org.codehaus.modello.*          = 0x84789D24DF77A32433CE1F079EB80E92EB2135B1, \
+                                  0x88BE34F94BDB2B5357044E2E3A387D43964143E3
+
 org.codehaus.mojo.*             = \
                                   0x02C66D06BB72026643F93BAED29E3DA204D79A77, \
                                   0x2A5AB419C0FB38AB767AAD2C4B3F4EDDC66C0F69, \


### PR DESCRIPTION
To help with (and similar in the group):
```
2024-05-05T08:24:18.8228097Z [ERROR] Not allowed artifact org.codehaus.modello:modello-plugin-converters:jar:2.4.0 and keyID:
2024-05-05T08:24:18.8230056Z 	org.codehaus.modello:modello-plugin-converters:2.4.0 = 0x84789D24DF77A32433CE1F079EB80E92EB2135B1
```
