### PR TITLE
Add new key for commons-validator

### DIFF
--- a/pgp-keys-map-test2/pom.xml
+++ b/pgp-keys-map-test2/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>apache-rat-api</artifactId>
             <version>[0.15]</version>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>[1.9.0]</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -100,6 +100,7 @@ commons-lang                    = \
 commons-logging:*:(,1.1.0]      = noSig
 commons-logging                 = \
                                   0x0CC641C3A62453AB390066C4A41F13C999945293, \
+                                  0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB, \
                                   0xB920D295BF0E61CB4CF0896C33CD6733AF5EC452
 
 commons-httpclient:*:(,3.0.1]   = noSig
@@ -116,6 +117,7 @@ commons-io                      = \
 commons-validator:*:(,1.3.0]    = noSig
 commons-validator:*:pom:1.3.1   = noSig
 commons-validator               = \
+                                  0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB, \
                                   0xCD5464315F0B98C77E6E8ECD9DAADC1C9FCC82D0, \
                                   0xD196A5E3E70732EEB2E5007F1861C322C56014B2, \
                                   0xD6F1BC78607808EC8E9F69437A8860944FAD5F62


### PR DESCRIPTION
This also adds [the same] key for `CV`'s dependency - `commons-logging`.