### PR TITLE
Add new key for org.hibernate.validator

### DIFF
--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -1063,7 +1063,8 @@ org.hamcrest                    = \
 org.hdrhistogram                = 0xE113159331A1F87BFC2A93D0960D2E8635A91268
 
 org.hibernate.*                 = noSig
-org.hibernate.validator         = 0x894F14D98D7F20D5E82645E3DFE102108BF9381F
+org.hibernate.validator         = 0x1452F35849B50750F6A3BBB4B54011358B352F85, \
+                                  0x894F14D98D7F20D5E82645E3DFE102108BF9381F
 
 org.iq80.snappy                 = 0x9E93DB1192CEE3D3B581AABB37E9D58EA4598641
 


### PR DESCRIPTION
New key was used to sign https://repo.maven.apache.org/maven2/org/hibernate/validator/hibernate-validator/8.0.2.Final/hibernate-validator-8.0.2.Final.jar

https://hibernate.org/community/keys/