### PR TITLE
Workaround for missing keys

### DIFF
--- a/org-apache-maven-plugins-test/pom.xml
+++ b/org-apache-maven-plugins-test/pom.xml
@@ -244,11 +244,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.26.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>3.8.0</version>
             </plugin>

--- a/pgp-keys-map-test1/pom.xml
+++ b/pgp-keys-map-test1/pom.xml
@@ -363,7 +363,7 @@
         <dependency>
             <groupId>io.vavr</groupId>
             <artifactId>vavr</artifactId>
-            <version>[0.10.5]</version>
+            <version>[0.10.6]</version>
         </dependency>
         <dependency>
             <groupId>jakarta.el</groupId>

--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -414,6 +414,7 @@ io.reformanda.semper            = 0x12019C612F8760FCE59238B55812C79D00186A37
 io.rsocket                      = 0x9B32CBC0F3F6BA4C13D611FC21871D2A9AB66A31
 
 io.vavr                         = \
+                                  0x0942F59B726DA4BD2837DD44F45F03308EE961FF, \
                                   0x1D339B6A68AE2E8DAEDA65D5276962CA56E73C81, \
                                   0x2E732921F44FD0DB434DB5CC55A58E21609DEC6E, \
                                   0x7F47B049D502F6E82C3AD35F9FF2FD540E29F945


### PR DESCRIPTION
m-pmd-p could be restored once new release is available (should use new key to sign)

- https://github.com/s4u/pgp-keys-map/pull/2784#issuecomment-2684754562