### PR TITLE
New key for commons-io

### DIFF
--- a/resources/pgp-keys-map.list
+++ b/resources/pgp-keys-map.list
@@ -116,7 +116,8 @@ commons-io                      = \
                                   0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB, \
                                   0x6BDACA2C0493CCA133B372D09C4F7E9D98B1CC53, \
                                   0xCD5464315F0B98C77E6E8ECD9DAADC1C9FCC82D0, \
-                                  0xD196A5E3E70732EEB2E5007F1861C322C56014B2
+                                  0xD196A5E3E70732EEB2E5007F1861C322C56014B2, \
+                                  0xF4DD59C90148BDC52BEB90A4530AA5F25C25011F
 
 commons-validator:*:(,1.3.0]    = noSig
 commons-validator:*:pom:1.3.1   = noSig


### PR DESCRIPTION
I see this as needed for _Bump commons-io:commons-io from 2.21.0 to 2.22.0_ just offered by dependabot here:
- #3448

-----

- #3449